### PR TITLE
Update dummy dependencies

### DIFF
--- a/schunk_egu_egk_gripper_dummy/README.md
+++ b/schunk_egu_egk_gripper_dummy/README.md
@@ -13,16 +13,22 @@ pip install --user fastapi uvicorn requests python-multipart
 ```
 
 ## Getting started
-- **Option 1**: Although shipped inside a ROS2 package, the dummy itself doesn't need ROS2.
-   You can simply navigate into the dummy's package and start it with
-    ```bash
-    ./start_dummy
-    ```
+There's a convenience script `start_dummy` for starting the dummy simulator.
+It will start on localhost with port `8000` by default but you can specify another port via the `port:=<port-id>` syntax.
 
-- **Option 2**: When working in a sourced environment, you can start the dummy with
-   ```bash
-   ros2 run schunk_egu_egk_gripper_dummy start_dummy
-   ```
+### Plain python
+
+Although shipped inside a ROS2 package, the dummy itself doesn't need ROS2.
+You can simply navigate into the dummy's package and start it with
+```bash
+./start_dummy port:=8000
+```
+
+### ROS2
+When working in a sourced ROS2 environment, you can start the dummy with
+```bash
+ros2 run schunk_egu_egk_gripper_dummy start_dummy --ros-args -p port:=8000
+```
 
 ## Run tests locally
 Inside the dummy's package

--- a/schunk_egu_egk_gripper_dummy/README.md
+++ b/schunk_egu_egk_gripper_dummy/README.md
@@ -9,7 +9,7 @@ We need additional Python dependencies.
 Install them inside your favorite Python environment with
 
 ```bash
-pip install --user fastapi uvicorn
+pip install --user fastapi uvicorn requests python-multipart
 ```
 
 ## Getting started

--- a/schunk_egu_egk_gripper_dummy/README.md
+++ b/schunk_egu_egk_gripper_dummy/README.md
@@ -1,19 +1,31 @@
 # Schunk EGU/EGK Dummy
 A minimalist protocol simulator for system tests.
 
+Use this SCHUNK gripper dummy whenever you don't have access to real hardware
+and still want to test your application.
+
 ## Dependencies
+We need additional Python dependencies.
+Install them inside your favorite Python environment with
 
 ```bash
 pip install --user fastapi uvicorn
 ```
 
 ## Getting started
-1. Start the dummy standalone with
+- **Option 1**: Although shipped inside a ROS2 package, the dummy itself doesn't need ROS2.
+   You can simply navigate into the dummy's package and start it with
     ```bash
-    ./start_dummy.sh
+    ./start_dummy
     ```
 
+- **Option 2**: When working in a sourced environment, you can start the dummy with
+   ```bash
+   ros2 run schunk_egu_egk_gripper_dummy start_dummy
+   ```
+
 ## Run tests locally
+Inside the dummy's package
 
 ```bash
 pip install --user pytest httpx coverage

--- a/schunk_egu_egk_gripper_dummy/config/__init__.py
+++ b/schunk_egu_egk_gripper_dummy/config/__init__.py
@@ -1,0 +1,2 @@
+# This file's existence lets setup.py install the config folder to site-packages.
+# We need this when starting this dummy with ros2 run.

--- a/schunk_egu_egk_gripper_dummy/setup.py
+++ b/schunk_egu_egk_gripper_dummy/setup.py
@@ -1,6 +1,5 @@
 from setuptools import find_packages, setup
 import os
-from glob import glob
 
 package_name = "schunk_egu_egk_gripper_dummy"
 
@@ -11,9 +10,7 @@ setup(
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),
-        (os.path.join("share", package_name), [package_name + "/main.py"]),
-        (os.path.join("share", package_name, "src"), glob("src/*.py")),
-        (os.path.join("share", package_name, "config"), glob("config/*.json")),
+        (os.path.join("lib", package_name), ["start_dummy"]),
     ],
     install_requires=["setuptools"],
     zip_safe=True,

--- a/schunk_egu_egk_gripper_dummy/start_dummy
+++ b/schunk_egu_egk_gripper_dummy/start_dummy
@@ -1,1 +1,2 @@
+#!/usr/bin/sh
 uvicorn schunk_egu_egk_gripper_dummy.main:server --port 8000 --reload

--- a/schunk_egu_egk_gripper_dummy/start_dummy
+++ b/schunk_egu_egk_gripper_dummy/start_dummy
@@ -1,2 +1,25 @@
 #!/usr/bin/sh
-uvicorn schunk_egu_egk_gripper_dummy.main:server --port 8000 --reload
+
+# Default port
+port=8000
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ros-args)
+      shift
+      ;;
+    -p|--port)
+      shift
+      ;;
+    port:*)
+      port="${1#*:=}"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+uvicorn schunk_egu_egk_gripper_dummy.main:server --port $port --reload


### PR DESCRIPTION
## Steps
- [x] Fix the install so that we can use the normal `ros2 run ..` syntax to start the dummy
- [x] Add missing dependencies in the readme
- [x] Allow the port argument for the start script