### PR TITLE
Add a mechanism for task scheduling

### DIFF
--- a/schunk_gripper_library/schunk_gripper_library/utility.py
+++ b/schunk_gripper_library/schunk_gripper_library/utility.py
@@ -1,0 +1,53 @@
+from threading import Thread
+from queue import PriorityQueue
+from concurrent.futures import Future
+from functools import partial
+
+
+class Task(object):
+    def __init__(self, future: Future | None = None, func: partial | None = None):
+        self.future: Future | None = future
+        self.func: partial | None = func
+
+    def __bool__(self):
+        if self.func is None:
+            return False
+        return True
+
+
+class Scheduler(object):
+    def __init__(self):
+        self.tasks: PriorityQueue = PriorityQueue()
+        self.worker_thread: Thread = Thread()
+
+    def start(self):
+        if not self.worker_thread.is_alive():
+            self.worker_thread = Thread(target=self._process, daemon=True)
+            self.worker_thread.start()
+
+    def stop(self):
+        self.tasks.put((0, Task()))  # highest priority
+        if self.worker_thread.is_alive():
+            self.worker_thread.join()
+        self.tasks = PriorityQueue()
+
+    def execute(self, func: partial, priority: int = 2) -> Future:
+        future: Future = Future()
+        if not self.worker_thread.is_alive():
+            future.set_result(False)
+            return future
+        if priority not in [1, 2]:
+            future.set_result(False)
+            return future
+        task = Task(func=func, future=future)
+        self.tasks.put((priority, task))
+        return future
+
+    def _process(self):
+        while True:
+            _, task = self.tasks.get()
+            if not task:
+                break
+            result = task.func()
+            task.future.set_result(result)
+            self.tasks.task_done()

--- a/schunk_gripper_library/schunk_gripper_library/utility.py
+++ b/schunk_gripper_library/schunk_gripper_library/utility.py
@@ -63,16 +63,20 @@ class Scheduler(object):
             return False
         task = Task(func=func, future=None)
         Thread(
-            target=self._cyclic_add,
-            kwargs={"task": task, "cycle_time": cycle_time, "priority": priority},
+            target=asyncio.run,
+            args=(
+                self._cyclic_add(task=task, cycle_time=cycle_time, priority=priority),
+            ),
             daemon=True,
         ).start()
         return True
 
-    def _cyclic_add(self, task: Task, cycle_time: float, priority: int = 2) -> None:
+    async def _cyclic_add(
+        self, task: Task, cycle_time: float, priority: int = 2
+    ) -> None:
         while self.worker_thread.is_alive():
             self.tasks.put((priority, task))
-            time.sleep(cycle_time)
+            await asyncio.sleep(cycle_time)
 
     def _process(self):
         while True:

--- a/schunk_gripper_library/schunk_gripper_library/utility.py
+++ b/schunk_gripper_library/schunk_gripper_library/utility.py
@@ -2,17 +2,25 @@ from threading import Thread
 from queue import PriorityQueue
 from concurrent.futures import Future
 from functools import partial
+import time
 
 
 class Task(object):
     def __init__(self, future: Future | None = None, func: partial | None = None):
         self.future: Future | None = future
         self.func: partial | None = func
+        self.stamp: float = time.time()
 
     def __bool__(self):
         if self.func is None:
             return False
         return True
+
+    def __lt__(self, other: "Task"):
+        return self.stamp < other.stamp
+
+    def __gt__(self, other: "Task"):
+        return self.stamp > other.stamp
 
 
 class Scheduler(object):

--- a/schunk_gripper_library/schunk_gripper_library/utility.py
+++ b/schunk_gripper_library/schunk_gripper_library/utility.py
@@ -3,6 +3,7 @@ from queue import PriorityQueue
 from concurrent.futures import Future
 from functools import partial
 import time
+import asyncio
 
 
 class Task(object):
@@ -57,5 +58,7 @@ class Scheduler(object):
             if not task:
                 break
             result = task.func()
+            if asyncio.iscoroutine(result):
+                result = asyncio.run(result)
             task.future.set_result(result)
             self.tasks.task_done()

--- a/schunk_gripper_library/tests/test_scheduling.py
+++ b/schunk_gripper_library/tests/test_scheduling.py
@@ -3,6 +3,7 @@ import threading
 from queue import PriorityQueue
 from functools import partial
 import time
+import asyncio
 
 
 def YES() -> bool:
@@ -152,3 +153,15 @@ def test_scheduler_executes_tasks_according_to_their_priorities():
     thread_high_priority.join()
     scheduler.stop()
     assert high_priority_finished < low_priority_finished
+
+
+def test_scheduler_supports_executing_coroutines():
+    scheduler = Scheduler()
+    scheduler.start()
+
+    async def coroutine():
+        await asyncio.sleep(1)
+        return True
+
+    assert scheduler.execute(func=partial(coroutine)).result()
+    scheduler.stop()

--- a/schunk_gripper_library/tests/test_scheduling.py
+++ b/schunk_gripper_library/tests/test_scheduling.py
@@ -211,3 +211,22 @@ def test_scheduler_rejects_invalid_arguments_for_cyclic_execution():
         assert not scheduler.cyclic_execute(func=partial(YES), cycle_time=cycle_time)
 
     scheduler.stop()
+
+
+def test_scheduler_manages_cyclic_execution_from_various_threads():
+    scheduler = Scheduler()
+    scheduler.start()
+
+    def run():
+        assert scheduler.cyclic_execute(func=partial(YES), cycle_time=0.01)
+
+    threads = []
+    for _ in range(10):
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        threads.append(thread)
+
+    time.sleep(1)  # run a little
+    scheduler.stop()
+    for thread in threads:
+        thread.join()

--- a/schunk_gripper_library/tests/test_scheduling.py
+++ b/schunk_gripper_library/tests/test_scheduling.py
@@ -1,0 +1,87 @@
+from ..schunk_gripper_library.utility import Task, Scheduler
+import threading
+from queue import PriorityQueue
+from functools import partial
+from concurrent.futures import Future
+
+
+def YES() -> bool:
+    return True
+
+
+def NO() -> bool:
+    return False
+
+
+def test_tasks_have_expected_initial_values():
+    task1 = Task()
+    assert task1.func is None
+    assert task1.future is None
+    task2 = Task(func=partial(YES), future=Future())
+    assert task2
+
+
+def test_tasks_have_boolean_meaning():
+    task = Task()
+    assert not task
+    task.func = "some function"
+    assert task
+
+
+def test_scheduler_runs_internal_worker_thread_when_started():
+    before = threading.active_count()
+    scheduler = Scheduler()
+    for _ in range(3):
+        scheduler.start()
+        assert threading.active_count() == before + 1
+        scheduler.stop()
+        assert threading.active_count() == before
+
+
+def test_schedular_supports_multiple_starts_and_stops():
+    scheduler = Scheduler()
+    before = threading.active_count()
+    for _ in range(3):
+        scheduler.start()
+    assert threading.active_count() == before + 1
+    for _ in range(3):
+        scheduler.stop()
+    assert threading.active_count() == before
+
+
+def test_scheduler_uses_a_priority_queue_for_tasks():
+    scheduler = Scheduler()
+    assert isinstance(scheduler.tasks, PriorityQueue)
+    assert scheduler.tasks.empty()  # on startup
+
+
+def test_scheduler_clears_tasks_on_stop():
+    scheduler = Scheduler()
+    task = Task()
+    scheduler.tasks.put((1, task))
+    scheduler.stop()
+    assert scheduler.tasks.empty()
+
+
+def test_scheduler_executes_tasks():
+    scheduler = Scheduler()
+    scheduler.start()
+    assert scheduler.execute(func=partial(YES)).result()
+    assert not scheduler.execute(func=partial(NO)).result()
+    scheduler.stop()
+
+
+def test_scheduler_rejects_tasks_when_not_connected():
+    scheduler = Scheduler()
+    assert not scheduler.execute(func=partial(YES)).result()
+    scheduler.start()
+    assert scheduler.execute(func=partial(YES)).result()
+    scheduler.stop()
+
+
+def test_scheduler_rejects_tasks_with_invalid_priority():
+    scheduler = Scheduler()
+    invalid_priorities = [0, -1, "asap", 3]
+    scheduler.start()
+    for priority in invalid_priorities:
+        assert not scheduler.execute(func=YES, priority=priority).result()


### PR DESCRIPTION
## Background
Industrial Modbus only supports a single client call at a time on the wire and requires careful synchronisation for dual-gripper setups. We'll use a priority queue for synchronized access.

## Steps
- [x] Implement a scheduler class
- [x] Support executing tasks from different threads
- [x] Support different priorities
- [x] Support cyclic execution 
