### PR TITLE
Add controlled stop

### DIFF
--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -177,6 +177,20 @@ class Driver(object):
         desired_bits = {"5": cmd_toggle_before ^ 1, "7": 1}
         return await self.wait_for_status(bits=desired_bits)
 
+    async def stop(self) -> bool:
+        if not self.connected:
+            return False
+
+        self.clear_plc_output()
+        self.send_plc_output()
+
+        cmd_toggle_before = self.get_status_bit(bit=5)
+        self.set_control_bit(bit=1, value=True)
+        self.send_plc_output()
+
+        desired_bits = {"5": cmd_toggle_before ^ 1, "13": 1, "4": 1}
+        return await self.wait_for_status(bits=desired_bits, timeout_sec=10)
+
     async def move_to_absolute_position(
         self, position: int, velocity: int, use_gpe: bool
     ) -> bool:

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -211,7 +211,7 @@ class Driver(object):
 
     async def move_to_relative_position(
         self, position: int, velocity: int, use_gpe: bool
-    ):
+    ) -> bool:
         if not self.connected:
             return False
 

--- a/schunk_gripper_library/tests/test_behavior.py
+++ b/schunk_gripper_library/tests/test_behavior.py
@@ -105,3 +105,22 @@ def test_move_to_relative_position():
         )
 
         assert driver.disconnect()
+
+
+@skip_without_gripper
+def test_stop():
+    driver = Driver()
+    for host, port, serial_port in zip(
+        ["0.0.0.0", None], [8000, None], [None, "/dev/ttyUSB0"]
+    ):
+        # Not connected
+        assert not asyncio.run(driver.stop())
+
+        # after connection
+        assert driver.connect(
+            host=host, port=port, serial_port=serial_port, device_id=12
+        )
+        assert asyncio.run(driver.acknowledge())
+
+        assert asyncio.run(driver.stop())
+        assert driver.disconnect()


### PR DESCRIPTION
## Implementing funtions
- [x] Controlled stop

### Notes
- Weird behaviour when testing stop before absolute and relative movement. Needs to be looked into
- Might need to add ```use_gpe``` as a parameter