### PR TITLE
Add `grip_at_position` and other features

### DIFF
--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -542,6 +542,20 @@ class Driver(object):
         desired_bits = {"5": cmd_toggle_before ^ 1, "8": 1}
         return await self.wait_for_status(bits=desired_bits, timeout_sec=2)
 
+    async def brake_test(self):
+        if not self.connected:
+            return False
+
+        self.clear_plc_output()
+        self.send_plc_output()
+        cmd_toggle_before = self.get_status_bit(bit=5)
+        self.set_control_bit(bit=30, value=True)
+        self.send_plc_output()
+
+        desired_bits = {"5": cmd_toggle_before ^ 1, "4": 1}
+
+        return await self.wait_for_status(bits=desired_bits)
+
     def receive_plc_input(self) -> bool:
         with self.input_buffer_lock:
             data = self.read_module_parameter(self.plc_input)

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -480,6 +480,39 @@ class Driver(object):
             return abs(still_to_go) / (ratio * self.module_parameters["max_grp_vel"])
         return 0.0
 
+    async def grip_workpiece_at_expected_position(
+        self,
+        gripping_force: int,
+        workpiece_pos: int,
+        use_gpe: bool,
+        gripping_velocity: int = 0,
+        grip_inside: bool = False,
+        grip_outside: bool = False,
+    ) -> bool:
+        if not self.connected:
+            return False
+
+        if grip_inside == grip_outside:
+            return False
+
+        if gripping_force < 0:
+            return False
+
+        self.clear_plc_output()
+        self.send_plc_output()
+
+        cmd_toggle_before = self.get_status_bit(bit=5)
+
+        self.set_control_bit(bit=16, value=True)
+        self.set_control_bit(bit=7, value=True if grip_inside else False)
+        self.set_gripping_force(gripping_force)
+        self.set_target_speed(gripping_velocity)
+        self.set_target_position(workpiece_pos)
+
+        self.send_plc_output()
+        desired_bits = {"5": cmd_toggle_before ^ 1, "4": 1, "12": 1}
+        return await self.wait_for_status(bits=desired_bits)
+
     def receive_plc_input(self) -> bool:
         with self.input_buffer_lock:
             data = self.read_module_parameter(self.plc_input)

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -513,6 +513,35 @@ class Driver(object):
         desired_bits = {"5": cmd_toggle_before ^ 1, "4": 1, "12": 1}
         return await self.wait_for_status(bits=desired_bits)
 
+    async def release_for_manual_movement(self) -> bool:
+        if not self.connected:
+            return False
+
+        self.clear_plc_output()
+        self.send_plc_output()
+        cmd_toggle_before = None
+
+        if self.get_status_bit(bit=7) == 1:
+            cmd_toggle_before = self.get_status_bit(bit=5)
+            self.set_control_bit(bit=5, value=True)
+            self.send_plc_output()
+        else:
+            self.set_control_bit(bit=0, value=False)
+            self.send_plc_output()
+            self.clear_plc_output()
+            desired_bits = {"7": 1}
+            if not await self.wait_for_status(bits=desired_bits):
+                return False
+            self.set_control_bit(bit=0, value=True)
+            self.send_plc_output()
+            self.clear_plc_output()
+            cmd_toggle_before = self.get_status_bit(bit=5)
+            self.set_control_bit(bit=5, value=True)
+            self.send_plc_output()
+
+        desired_bits = {"5": cmd_toggle_before ^ 1, "8": 1}
+        return await self.wait_for_status(bits=desired_bits, timeout_sec=2)
+
     def receive_plc_input(self) -> bool:
         with self.input_buffer_lock:
             data = self.read_module_parameter(self.plc_input)

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
@@ -303,3 +303,63 @@ def test_release():
             assert driver.release(use_gpe=True)
 
         assert driver.disconnect()
+
+
+@skip_without_gripper
+def test_grip_workpiece_at_expected_position():
+    # values for example 6
+    test_force = 91  # %
+    test_gpe = True
+    test_inside = True
+    test_outside = False
+    test_vel = 0
+    test_pos = 38000
+
+    driver = Driver()
+    for host, port, serial_port in zip(
+        ["0.0.0.0", None], [8000, None], [None, "/dev/ttyUSB0"]
+    ):
+        # not connected
+        assert not asyncio.run(
+            driver.grip_workpiece_at_expected_position(
+                gripping_force=test_force,
+                grip_inside=True if test_inside else False,
+                grip_outside=True if test_outside else False,
+                use_gpe=test_gpe,
+                workpiece_pos=test_pos,
+            )
+        )
+
+        # after connection
+        assert driver.connect(
+            host=host, port=port, serial_port=serial_port, device_id=12
+        )
+        assert asyncio.run(driver.acknowledge())
+
+        assert not asyncio.run(
+            driver.grip_workpiece_at_expected_position(
+                gripping_force=test_force,
+                grip_inside=True,
+                grip_outside=True,
+                use_gpe=test_gpe,
+                workpiece_pos=test_pos,
+            )
+        )
+
+        # Modbus testing not possible, hence this skip
+        if serial_port:
+            assert driver.disconnect()
+            return
+
+        assert asyncio.run(
+            driver.grip_workpiece_at_expected_position(
+                gripping_force=test_force,
+                grip_inside=True if test_inside else False,
+                grip_outside=True if test_outside else False,
+                use_gpe=test_gpe,
+                workpiece_pos=test_pos,
+                gripping_velocity=test_vel,
+            )
+        )
+
+        assert driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
@@ -363,3 +363,25 @@ def test_grip_workpiece_at_expected_position():
         )
 
         assert driver.disconnect()
+
+
+@skip_without_gripper
+def test_remove_workpiece_manually():
+    driver = Driver()
+
+    for host, port, serial_port in zip(
+        ["0.0.0.0", None], [8000, None], [None, "/dev/ttyUSB0"]
+    ):
+        assert not asyncio.run(driver.release_for_manual_movement())
+
+        assert driver.connect(
+            host=host, port=port, serial_port=serial_port, device_id=12
+        )
+        # not in error state
+        assert asyncio.run(driver.acknowledge())
+        assert asyncio.run(driver.release_for_manual_movement())
+        # in error state
+        assert asyncio.run(driver.fast_stop())
+        assert asyncio.run(driver.release_for_manual_movement()), host
+
+        assert driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
@@ -385,3 +385,24 @@ def test_remove_workpiece_manually():
         assert asyncio.run(driver.release_for_manual_movement()), host
 
         assert driver.disconnect()
+
+
+@skip_without_gripper
+def test_brake_test():
+    driver = Driver()
+
+    for host, port, serial_port in zip(
+        ["0.0.0.0", None], [8000, None], [None, "/dev/ttyUSB0"]
+    ):
+        # Webserver functionality not yet implemented
+        if port:
+            return
+        assert not asyncio.run(driver.brake_test())
+
+        assert driver.connect(
+            host=host, port=port, serial_port=serial_port, device_id=12
+        )
+        assert asyncio.run(driver.acknowledge())
+
+        assert asyncio.run(driver.brake_test())
+        assert driver.disconnect()


### PR DESCRIPTION
## Library functions

- [x] Remove workpiece manually
- [x] Workpiece gripping at expected position (not fully tested)
- [x] Brake test

## Additional steps
- [ ] Refactor functions to use the _scheduler_ approach
- [ ] Implement ROS2 service for
   - [ ] Remove workpiece manually
   - [ ] Grip at expected position
   - [ ] Brake test 