### PR TITLE
Publish the grippers' state as ROS2 topic

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -103,21 +103,27 @@ def test_driver_manages_services_for_each_gripper(ros2: None):
 
 
 @skip_without_gripper
-def test_driver_manages_topics_for_each_gripper(ros2: None):
+def test_driver_manages_publishers_for_each_gripper(ros2: None):
     driver = Driver("driver")
 
     for _ in range(3):
-        assert driver.gripper_topics == {}
+        assert driver.joint_state_publishers == {}
+        assert driver.gripper_state_publishers == {}
         driver.on_configure(state=None)
-        assert driver.gripper_topics == {}
+        assert driver.joint_state_publishers == {}
+        assert driver.gripper_state_publishers == {}
 
         driver.on_activate(state=None)
-        assert len(driver.gripper_topics) >= 1
+        nr_grippers = len(driver.list_grippers())
+        assert len(driver.joint_state_publishers) == nr_grippers
+        assert len(driver.gripper_state_publishers) == nr_grippers
 
         driver.on_deactivate(state=None)
-        assert driver.gripper_topics == {}
+        assert driver.joint_state_publishers == {}
+        assert driver.gripper_state_publishers == {}
         driver.on_cleanup(state=None)
-        assert driver.gripper_topics == {}
+        assert driver.joint_state_publishers == {}
+        assert driver.gripper_state_publishers == {}
 
 
 @skip_without_gripper

--- a/schunk_gripper_interfaces/CMakeLists.txt
+++ b/schunk_gripper_interfaces/CMakeLists.txt
@@ -19,6 +19,7 @@ rosidl_generate_interfaces(
     srv/Release.srv
     srv/ShowConfiguration.srv
     msg/Gripper.msg
+    msg/GripperState.msg
   DEPENDENCIES
     std_msgs
 )

--- a/schunk_gripper_interfaces/msg/GripperState.msg
+++ b/schunk_gripper_interfaces/msg/GripperState.msg
@@ -1,0 +1,20 @@
+std_msgs/Header header
+
+# Bits from the gripper's plc status double word
+bool bit0_ready_for_operation
+bool bit1_control_authority_fieldbus
+bool bit2_ready_for_shutdown
+bool bit3_not_feasible
+bool bit4_command_successfully_processed
+bool bit5_command_received_toggle
+bool bit6_warning
+bool bit7_error
+bool bit8_released_for_manual_movement
+bool bit9_software_limit_reached
+bool bit11_no_workpiece_detected
+bool bit12_workpiece_gripped
+bool bit13_position_reached
+bool bit14_workpiece_pre_grip_started
+bool bit16_workpiece_lost
+bool bit17_wrong_workpiece_gripped
+bool bit31_grip_force_and_position_maintenance_activated


### PR DESCRIPTION
This will be high-level callers' access to low-level status information.