### PR TITLE
Support field buses

### DIFF
--- a/schunk_gripper_library/schunk_gripper_library/config/readable_parameters.json
+++ b/schunk_gripper_library/schunk_gripper_library/config/readable_parameters.json
@@ -1,10 +1,10 @@
 {
-    "0x0040": {"name": "plc_input", "registers": 8, "format": "", "type": "uint32 int32 uint32 uint32"},
-    "0x0500": {"name": "module_type", "registers": 1, "format": "h", "type": "enum"},
-    "0x0540": {"name": "wp_release_delta", "registers": 2, "format": "f", "type": "float"},
-    "0x0600": {"name": "min_pos", "registers": 2, "format": "f", "type": "float"},
-    "0x0608": {"name": "max_pos", "registers": 2, "format": "f", "type": "float"},
-    "0x0630": {"name": "max_vel", "registers": 2, "format": "f", "type": "float"},
-    "0x0650": {"name": "max_grp_vel", "registers": 2, "format": "f", "type": "float"},
-    "0x1130": {"name": "fieldbus_type", "registers": 1, "format": "h", "type": "enum"}
+    "0x0040": {"name": "plc_input", "registers": 8, "type": "uint32 int32 uint32 uint32"},
+    "0x0500": {"name": "module_type", "registers": 1, "type": "enum"},
+    "0x0540": {"name": "wp_release_delta", "registers": 2, "type": "float"},
+    "0x0600": {"name": "min_pos", "registers": 2, "type": "float"},
+    "0x0608": {"name": "max_pos", "registers": 2, "type": "float"},
+    "0x0630": {"name": "max_vel", "registers": 2, "type": "float"},
+    "0x0650": {"name": "max_grp_vel", "registers": 2, "type": "float"},
+    "0x1130": {"name": "fieldbus_type", "registers": 1, "type": "enum"}
 }

--- a/schunk_gripper_library/schunk_gripper_library/config/readable_parameters.json
+++ b/schunk_gripper_library/schunk_gripper_library/config/readable_parameters.json
@@ -1,10 +1,10 @@
 {
-    "0x0040": {"registers": 8, "type": "uint32 int32 uint32 uint32"},
-    "0x0500": {"registers": 1, "type": "enum"},
-    "0x0540": {"registers": 2, "type": "float"},
-    "0x0600": {"registers": 2, "type": "float"},
-    "0x0608": {"registers": 2, "type": "float"},
-    "0x0630": {"registers": 2, "type": "float"},
-    "0x0650": {"registers": 2, "type": "float"},
-    "0x1130": {"registers": 1, "type": "enum"}
+    "0x0040": {"name": "plc_input", "registers": 8, "format": "", "type": "uint32 int32 uint32 uint32"},
+    "0x0500": {"name": "module_type", "registers": 1, "format": "h", "type": "enum"},
+    "0x0540": {"name": "wp_release_delta", "registers": 2, "format": "f", "type": "float"},
+    "0x0600": {"name": "min_pos", "registers": 2, "format": "f", "type": "float"},
+    "0x0608": {"name": "max_pos", "registers": 2, "format": "f", "type": "float"},
+    "0x0630": {"name": "max_vel", "registers": 2, "format": "f", "type": "float"},
+    "0x0650": {"name": "max_grp_vel", "registers": 2, "format": "f", "type": "float"},
+    "0x1130": {"name": "fieldbus_type", "registers": 1, "format": "h", "type": "enum"}
 }

--- a/schunk_gripper_library/schunk_gripper_library/config/readable_parameters.json
+++ b/schunk_gripper_library/schunk_gripper_library/config/readable_parameters.json
@@ -5,5 +5,6 @@
     "0x0600": {"registers": 2, "type": "float"},
     "0x0608": {"registers": 2, "type": "float"},
     "0x0630": {"registers": 2, "type": "float"},
-    "0x0650": {"registers": 2, "type": "float"}
+    "0x0650": {"registers": 2, "type": "float"},
+    "0x1130": {"registers": 1, "type": "enum"}
 }

--- a/schunk_gripper_library/schunk_gripper_library/config/writable_parameters.json
+++ b/schunk_gripper_library/schunk_gripper_library/config/writable_parameters.json
@@ -1,3 +1,3 @@
 {
-    "0x0048": {"name": "plc_output", "registers": 8, "format": "", "type": "uint32 int32 int32 uint32"}
+    "0x0048": {"name": "plc_output", "registers": 8, "type": "uint32 int32 int32 uint32"}
 }

--- a/schunk_gripper_library/schunk_gripper_library/config/writable_parameters.json
+++ b/schunk_gripper_library/schunk_gripper_library/config/writable_parameters.json
@@ -1,3 +1,3 @@
 {
-    "0x0048": {"registers": 8, "type": "uint32 int32 int32 uint32"}
+    "0x0048": {"name": "plc_output", "registers": 8, "format": "", "type": "uint32 int32 int32 uint32"}
 }

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -468,9 +468,9 @@ class Driver(object):
             if fields["name"] in self.module_parameters:
                 if not (data := self.read_module_parameter(param)):
                     return False
-                if fields["format"] == "f":
+                if fields["type"] == "float":
                     value = int(struct.unpack("f", data)[0] * 1e3)
-                elif fields["format"] == "h":
+                elif fields["type"] == "enum":
                     value = int(struct.unpack("h", data)[0])
                 else:
                     return False

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -60,6 +60,7 @@ class Driver(object):
             "max_vel": None,
             "max_grp_vel": None,
             "wp_release_delta": None,
+            "fieldbus_type": None,
         }
         # fmt: off
         self.valid_status_bits: list[int] = (
@@ -489,6 +490,12 @@ class Driver(object):
         self.module_parameters["wp_release_delta"] = int(
             struct.unpack("f", data)[0] * 1e3
         )
+
+        # fieldbus_type
+        if not (data := self.read_module_parameter("0x1130")):
+            return False
+        self.module_parameters["fieldbus_type"] = int(struct.unpack("h", data)[0])
+
         return True
 
     def read_module_parameter(self, param: str) -> bytearray:

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -464,37 +464,20 @@ class Driver(object):
                 self.module_parameters[key] = None
             return True
 
-        # min_pos
-        if not (data := self.read_module_parameter("0x0600")):
-            return False
-        self.module_parameters["min_pos"] = int(struct.unpack("f", data)[0] * 1e3)
+        for param, fields in self.readable_parameters.items():
+            if fields["name"] in self.module_parameters:
+                if not (data := self.read_module_parameter(param)):
+                    return False
+                if fields["format"] == "f":
+                    value = int(struct.unpack("f", data)[0] * 1e3)
+                elif fields["format"] == "h":
+                    value = int(struct.unpack("h", data)[0])
+                else:
+                    return False
+                self.module_parameters[fields["name"]] = value
 
-        # max_pos
-        if not (data := self.read_module_parameter("0x0608")):
+        if any([entry is None for entry in self.module_parameters.values()]):
             return False
-        self.module_parameters["max_pos"] = int(struct.unpack("f", data)[0] * 1e3)
-
-        # max_vel
-        if not (data := self.read_module_parameter("0x0630")):
-            return False
-        self.module_parameters["max_vel"] = int(struct.unpack("f", data)[0] * 1e3)
-
-        # max_grp_vel
-        if not (data := self.read_module_parameter("0x0650")):
-            return False
-        self.module_parameters["max_grp_vel"] = int(struct.unpack("f", data)[0] * 1e3)
-
-        # wp_release_delta
-        if not (data := self.read_module_parameter("0x0540")):
-            return False
-        self.module_parameters["wp_release_delta"] = int(
-            struct.unpack("f", data)[0] * 1e3
-        )
-
-        # fieldbus_type
-        if not (data := self.read_module_parameter("0x1130")):
-            return False
-        self.module_parameters["fieldbus_type"] = int(struct.unpack("h", data)[0])
 
         return True
 

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -484,7 +484,14 @@ def test_driver_estimates_duration_of_release():
 @skip_without_gripper
 def test_connected_driver_has_module_parameters():
     driver = Driver()
-    params = ["max_grp_vel", "max_vel", "min_pos", "max_pos", "wp_release_delta"]
+    params = [
+        "max_grp_vel",
+        "max_vel",
+        "min_pos",
+        "max_pos",
+        "wp_release_delta",
+        "fieldbus_type",
+    ]
     for param in params:
         assert param in driver.module_parameters
         assert driver.module_parameters[param] is None


### PR DESCRIPTION
## Background
Fieldbuses have different endianness.
Do we need to consider this for _TCP/IP_ communication?

**Check**:
EtherCAT: little-endian?
EtherNet/IP: big-endian?
PROFINET: big-endian?

---

## Steps
- [ ] Check if we need to consider endianness for parameter parsing
- [ ] Test with hardware