### PR TITLE
Minimal log footprint

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -149,7 +149,7 @@ class Driver(Node):
         return False
 
     def on_configure(self, state: State) -> TransitionCallbackReturn:
-        self.get_logger().info("on_configure() is called.")
+        self.get_logger().debug("on_configure() is called.")
         self.scheduler.start()
 
         # Connect each gripper
@@ -197,7 +197,7 @@ class Driver(Node):
         return TransitionCallbackReturn.SUCCESS
 
     def on_activate(self, state: State) -> TransitionCallbackReturn:
-        self.get_logger().info("on_activate() is called.")
+        self.get_logger().debug("on_activate() is called.")
 
         # Gripper-specific services
         for idx, _ in enumerate(self.grippers):
@@ -278,7 +278,7 @@ class Driver(Node):
         return super().on_activate(state)
 
     def on_deactivate(self, state: State) -> TransitionCallbackReturn:
-        self.get_logger().info("on_deactivate() is called.")
+        self.get_logger().debug("on_deactivate() is called.")
 
         # Release gripper-specific services
         for idx, _ in enumerate(self.gripper_services):
@@ -296,7 +296,7 @@ class Driver(Node):
         return super().on_deactivate(state)
 
     def on_cleanup(self, state: State) -> TransitionCallbackReturn:
-        self.get_logger().info("on_cleanup() is called.")
+        self.get_logger().debug("on_cleanup() is called.")
         self.scheduler.stop()
         for gripper in self.grippers:
             gripper["driver"].disconnect()
@@ -320,7 +320,7 @@ class Driver(Node):
         return TransitionCallbackReturn.SUCCESS
 
     def on_shutdown(self, state: State) -> TransitionCallbackReturn:
-        self.get_logger().info("on_shutdown() is called.")
+        self.get_logger().debug("on_shutdown() is called.")
 
         def kill() -> None:
             time.sleep(0.1)
@@ -405,7 +405,7 @@ class Driver(Node):
     def _list_grippers_cb(
         self, request: ListGrippers.Request, response: ListGrippers.Response
     ):
-        self.get_logger().info("---> List gripper IDs")
+        self.get_logger().debug("---> List gripper IDs")
         response.grippers = self.list_grippers()
         return response
 
@@ -415,7 +415,7 @@ class Driver(Node):
         response: Trigger.Response,
         gripper: Gripper,
     ):
-        self.get_logger().info("---> Acknowledge")
+        self.get_logger().debug("---> Acknowledge")
         if self.needs_synchronize(gripper):
             response.success = asyncio.run(
                 gripper["driver"].acknowledge(scheduler=self.scheduler)
@@ -431,7 +431,7 @@ class Driver(Node):
         response: Trigger.Response,
         gripper: Gripper,
     ):
-        self.get_logger().info("---> Fast stop")
+        self.get_logger().debug("---> Fast stop")
         if self.needs_synchronize(gripper):
             response.success = gripper["driver"].fast_stop(scheduler=self.scheduler)
         else:
@@ -445,7 +445,7 @@ class Driver(Node):
         response: MoveToAbsolutePosition.Response,
         gripper: Gripper,
     ):
-        self.get_logger().info("---> Move to absolute position")
+        self.get_logger().debug("---> Move to absolute position")
         position = int(request.position * 1e6)
         velocity = int(request.velocity * 1e6)
         if self.needs_synchronize(gripper):
@@ -472,7 +472,7 @@ class Driver(Node):
         response: Grip.Response,
         gripper: Gripper,
     ):
-        self.get_logger().info("---> Grip")
+        self.get_logger().debug("---> Grip")
         if self.needs_synchronize(gripper):
             response.success = asyncio.run(
                 gripper["driver"].grip(
@@ -499,7 +499,7 @@ class Driver(Node):
         response: Release.Response,
         gripper: Gripper,
     ):
-        self.get_logger().info("---> Release")
+        self.get_logger().debug("---> Release")
         if self.needs_synchronize(gripper):
             response.success = asyncio.run(
                 gripper["driver"].release(

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
@@ -26,6 +26,30 @@ from rcl_interfaces.srv import SetParameters
 from schunk_gripper_interfaces.srv import ListGrippers  # type: ignore [attr-defined]
 
 from rclpy.node import Node
+import os
+
+
+def get_directory_size(directory):
+    total_size = 0
+    for dirpath, dirnames, filenames in os.walk(directory):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            total_size += os.path.getsize(fp)
+    return total_size
+
+
+@pytest.fixture(scope="module")
+def log_monitor(request, tmpdir_factory):
+    log_dir = str(tmpdir_factory.mktemp("log_dir"))
+    os.environ["ROS_LOG_DIR"] = log_dir
+
+    print(f"log_size before: {get_directory_size(log_dir)} Bytes")
+
+    yield
+
+    after = get_directory_size(log_dir)
+    print(f"log_size after: {after} Bytes")
+    assert after < request.param.get("max_log_size")
 
 
 @pytest.fixture(scope="module")

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_logging.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_logging.py
@@ -1,0 +1,41 @@
+# Copyright 2025 SCHUNK SE & Co. KG
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+# --------------------------------------------------------------------------------
+from schunk_gripper_library.utility import skip_without_gripper
+from lifecycle_msgs.msg import Transition
+import time
+import pytest
+
+LOG_SIZE_BYTES = 100
+
+
+@skip_without_gripper
+@pytest.mark.parametrize(
+    "log_monitor", [{"max_log_size": LOG_SIZE_BYTES}], indirect=True
+)
+def test_driver_doesnt_fill_disk_space_by_default(log_monitor, lifecycle_interface):
+    driver = lifecycle_interface
+
+    for _ in range(10):
+
+        driver.change_state(Transition.TRANSITION_CONFIGURE)
+        driver.change_state(Transition.TRANSITION_ACTIVATE)
+
+        time.sleep(0.1)
+
+        driver.change_state(Transition.TRANSITION_DEACTIVATE)
+        driver.change_state(Transition.TRANSITION_CLEANUP)
+
+    # log_monitor does the final asserting

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_logging.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_logging.py
@@ -18,7 +18,7 @@ from lifecycle_msgs.msg import Transition
 import time
 import pytest
 
-LOG_SIZE_BYTES = 100
+LOG_SIZE_BYTES = 500  # Minimal output for driver startup and shutdown
 
 
 @skip_without_gripper

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -155,9 +155,9 @@ class Driver(object):
                     baudrate=115200,
                     parity="N",
                     stopbits=1,
-                    trace_connect=self._trace_connect,
-                    trace_packet=self._trace_packet,
-                    trace_pdu=self._trace_pdu,
+                    trace_connect=None,
+                    trace_packet=None,
+                    trace_pdu=None,
                 )
                 self.connected = self.mb_client.connect()
 


### PR DESCRIPTION
## Steps
- [x] Drop tracing methods in the Modbus client
- [x] Add a test for checking the log footprint of the running driver
- [x] Use `debug` level for most of the driver's outputs