### PR TITLE
Run publishers concurrently

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -417,3 +417,28 @@ def test_driver_shows_configuration(ros2: None):
     # After reset
     driver.reset_grippers()
     assert driver.show_configuration() == []
+
+
+@skip_without_gripper
+def test_driver_uses_separate_callback_group_for_publishers(ros2: None):
+    driver = Driver("driver")
+
+    driver.on_configure(state=None)
+    driver.on_activate(state=None)
+
+    # Joint states
+    for publisher in driver.joint_state_publishers.values():
+        for handler in publisher.event_handlers:
+            assert handler.callback_group != driver.default_callback_group
+
+    # Gripper state
+    for publisher in driver.gripper_state_publishers.values():
+        for handler in publisher.event_handlers:
+            assert handler.callback_group != driver.default_callback_group
+
+    # Timers
+    for timer in driver.gripper_timers:
+        assert timer.callback_group != driver.default_callback_group
+
+    driver.on_deactivate(state=None)
+    driver.on_cleanup(state=None)

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -284,12 +284,12 @@ def test_driver_implements_grip_and_release(lifecycle_interface):
             request.use_gpe = target["use_gpe"]
             request.outward = target["outward"]
             future = grip_client.call_async(request)
-            rclpy.spin_until_future_complete(node, future, timeout_sec=3)
+            rclpy.spin_until_future_complete(node, future)
             assert future.result().success, f"{future.result().message}"
 
             # Release
             future = release_client.call_async(Release.Request())
-            rclpy.spin_until_future_complete(node, future, timeout_sec=3)
+            rclpy.spin_until_future_complete(node, future)
             assert future.result().success, f"{future.result().message}"
 
     driver.change_state(Transition.TRANSITION_DEACTIVATE)

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -346,7 +346,7 @@ class Driver(object):
             desired_bits = {"4": 1, "12": 1}
             return await self.wait_for_status(bits=desired_bits)
 
-        duration_sec = self.estimate_duration(force=force)
+        duration_sec = self.estimate_duration(force=force, outward=outward)
         if scheduler:
             if not scheduler.execute(func=partial(start)).result():
                 return False

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
@@ -238,6 +238,23 @@ def test_grip_works_with_valid_arguments():
         assert asyncio.run(driver.grip(**args))
     driver.disconnect()
 
+    # Check that outward moves in the right directions.
+    # Only Modbus for now, the web dummy succeeds without moving.
+    driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
+    max_pos = driver.module_parameters["max_pos"]
+    min_pos = driver.module_parameters["min_pos"]
+    middle = int(0.5 * (max_pos - min_pos))
+
+    asyncio.run(driver.acknowledge())
+    asyncio.run(driver.grip(force=100, outward=True))
+    assert driver.get_actual_position() > middle
+
+    asyncio.run(driver.acknowledge())
+    asyncio.run(driver.grip(force=100, outward=False))
+    assert driver.get_actual_position() < middle
+
+    driver.disconnect()
+
 
 @skip_without_gripper
 def test_grip_fails_when_no_workpiece_detected():


### PR DESCRIPTION
## Steps
- [x] Make sure publishers publish even for long-lasting service calls
- [x] Fix `grip` with `outward=True` on the way