### PR TITLE
Fail `configure` with empty grippers list

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -155,6 +155,8 @@ class Driver(Node):
 
     def on_configure(self, state: State) -> TransitionCallbackReturn:
         self.get_logger().debug("on_configure() is called.")
+        if not self.grippers:
+            return TransitionCallbackReturn.FAILURE
         self.scheduler.start()
 
         # Connect each gripper

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -27,6 +27,7 @@ from schunk_gripper_interfaces.msg import (  # type: ignore [attr-defined]
     Gripper as GripperConfig,
 )
 from schunk_gripper_driver.driver import Gripper
+from rclpy.lifecycle import TransitionCallbackReturn
 
 
 def test_driver_manages_a_list_of_grippers(ros2: None):
@@ -442,3 +443,11 @@ def test_driver_uses_separate_callback_group_for_publishers(ros2: None):
 
     driver.on_deactivate(state=None)
     driver.on_cleanup(state=None)
+
+
+def test_driver_doesnt_configure_with_empty_grippers(ros2):
+    driver = Driver("test_empty_configure")
+    driver.reset_grippers()
+
+    result = driver.on_configure(state=None)
+    assert result == TransitionCallbackReturn.FAILURE


### PR DESCRIPTION
A successful `configure` should guarantee users that they obtain an operational driver.
This wasn't the case before.