### PR TITLE
Fix behavior tests

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 
 # Avoid duplicates in the sub directories
-exclude = (setup.py$)
+exclude = (setup.py$|build|install)
 
 # 3rd-party libraries
 [mypy-rclpy.*]

--- a/schunk_gripper_dummy/schunk_gripper_dummy/dummy.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/dummy.py
@@ -72,15 +72,17 @@ class Dummy(object):
         self.initial_state = [self.plc_input_buffer.hex().upper()]
         self.clear_plc_output()
 
-        self.min_position = struct.unpack(
-            "i", bytearray(bytes.fromhex(self.data["0x0600"][0])[::-1])
-        )[0]
-        self.max_position = struct.unpack(
-            "i", bytearray(bytes.fromhex(self.data["0x0608"][0])[::-1])
-        )[0]
         self.max_grp_vel = struct.unpack(
             "i", bytearray(bytes.fromhex(self.data["0x0650"][0])[::-1])
         )[0]
+        min_pos_per_jaw = struct.unpack(
+            "i", bytearray(bytes.fromhex(self.data["0x0600"][0])[::-1])
+        )[0]
+        max_pos_per_jaw = struct.unpack(
+            "i", bytearray(bytes.fromhex(self.data["0x0608"][0])[::-1])
+        )[0]
+        self.min_position = 2 * min_pos_per_jaw
+        self.max_position = 2 * max_pos_per_jaw
 
     def start(self) -> None:
         if self.running:

--- a/schunk_gripper_dummy/schunk_gripper_dummy/dummy.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/dummy.py
@@ -296,11 +296,12 @@ class Dummy(object):
         https://stb.cloud.schunk.com/media/IM0046706.PDF
 
         """
-        # Reset success of previous commands
-        self.set_status_bit(bit=4, value=False)
-        self.set_status_bit(bit=8, value=False)
-        self.set_status_bit(bit=12, value=False)
-        self.set_status_bit(bit=13, value=False)
+        # Reset status bits of previous commands
+        for bit in self.valid_status_bits:
+            if bit in [5, 7]:
+                pass
+            else:
+                self.set_status_bit(bit=bit, value=False)
 
         # Clearing all control bits doesn't trigger any action
         if self.get_plc_output()[0] == "01" + "00" * 15:
@@ -377,6 +378,11 @@ class Dummy(object):
 
         # Move to absolute position
         if self.get_control_bit(bit=13) == 1:
+            if self.get_target_speed() <= 0:
+                self.set_status_bit(bit=3, value=True)
+                self.clear_plc_output()
+                return
+
             self.move(
                 target_pos=self.get_target_position(),
                 target_speed=self.get_target_speed(),

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
@@ -238,6 +238,11 @@ def test_grip_works_with_valid_arguments():
         assert asyncio.run(driver.grip(**args))
     driver.disconnect()
 
+
+@skip_without_gripper
+def test_grip_moves_as_expected_with_the_outward_argument():
+    driver = Driver()
+
     # Check that outward moves in the right directions.
     # Only Modbus for now, the web dummy succeeds without moving.
     driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
@@ -249,8 +254,8 @@ def test_grip_works_with_valid_arguments():
     asyncio.run(driver.grip(force=100, outward=True))
     assert driver.get_actual_position() > middle
 
-    asyncio.run(driver.acknowledge())
-    asyncio.run(driver.grip(force=100, outward=False))
+    assert asyncio.run(driver.acknowledge())
+    assert asyncio.run(driver.grip(force=100, outward=False))
     assert driver.get_actual_position() < middle
 
     driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
@@ -243,19 +243,18 @@ def test_grip_works_with_valid_arguments():
 def test_grip_moves_as_expected_with_the_outward_argument():
     driver = Driver()
 
-    # Check that outward moves in the right directions.
-    # Only Modbus for now, the web dummy succeeds without moving.
-    driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
+    # Check that gripper's jaws moves in the right directions.
+    driver.connect(host="0.0.0.0", port=8000)
     max_pos = driver.module_parameters["max_pos"]
     min_pos = driver.module_parameters["min_pos"]
     middle = int(0.5 * (max_pos - min_pos))
 
-    asyncio.run(driver.acknowledge())
+    assert asyncio.run(driver.acknowledge())
     asyncio.run(driver.grip(force=100, outward=True))
     assert driver.get_actual_position() > middle
 
     assert asyncio.run(driver.acknowledge())
-    assert asyncio.run(driver.grip(force=100, outward=False))
+    asyncio.run(driver.grip(force=100, outward=False))
     assert driver.get_actual_position() < middle
 
     driver.disconnect()


### PR DESCRIPTION
## Background
The behavior tests were not really deterministic and failed from time to time. We really need to make this work.

## Steps
- [x] Split the `test_grip_works_with_valid_arguments` into two individual tests
- [x] Adjust the `grip` command in the dummy
- [x] Reject zero velocity arguments in the dummy
- [x] Fix the `outward` test
- [x] Make the Modbus `test_behavior` stable

---
Edit: The tests now run stable if we freshly restart the BKS simulator before each complete test run.
However, due to non-RT OS behavior, we cannot rely on the time computation for the _movement_-related commands to be exact like the real hardware guarantees us. We'll probably need to fix/adapt the general test concept here (different PR).