### PR TITLE
Improve gripper specification

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -483,6 +483,8 @@ class Driver(Node):
         response.specification.max_force = spec["max_force"]
         response.specification.serial_number = spec["serial_number"]
         response.specification.firmware_version = spec["firmware_version"]
+        response.specification.device_id = spec.get("device_id", 0)
+        response.specification.ip_address = spec.get("ip_address", "")
         response.success = True
         response.message = gripper["driver"].get_status_diagnostics()
         return response

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -483,8 +483,8 @@ class Driver(Node):
         response.specification.max_force = spec["max_force"]
         response.specification.serial_number = spec["serial_number"]
         response.specification.firmware_version = spec["firmware_version"]
-        response.specification.device_id = spec.get("device_id", 0)
-        response.specification.ip_address = spec.get("ip_address", "")
+        response.specification.device_id = spec["device_id"]
+        response.specification.ip_address = spec["ip_address"]
         response.success = True
         response.message = gripper["driver"].get_status_diagnostics()
         return response

--- a/schunk_gripper_interfaces/msg/GripperSpec.msg
+++ b/schunk_gripper_interfaces/msg/GripperSpec.msg
@@ -3,5 +3,5 @@ float32 max_speed       # The gripper's maximum speed in mm/s
 float32 max_force       # The gripper's maximum force in N
 string serial_number    # The gripper's serial number
 string firmware_version # The gripper's firmware version
-uint8 device_id         # The gripper's deviceID (Modbus based)
-string ip_address       # The gripper's IP address (Ethernet based)
+uint8 device_id         # The gripper's device ID (for Modbus grippers)
+string ip_address       # The gripper's IP address (for Ethernet-based grippers)

--- a/schunk_gripper_interfaces/msg/GripperSpec.msg
+++ b/schunk_gripper_interfaces/msg/GripperSpec.msg
@@ -3,3 +3,5 @@ float32 max_speed       # The gripper's maximum speed in mm/s
 float32 max_force       # The gripper's maximum force in N
 string serial_number    # The gripper's serial number
 string firmware_version # The gripper's firmware version
+uint8 device_id         # The gripper's deviceID (Modbus based)
+string ip_address       # The gripper's IP address (Ethernet based)

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -411,12 +411,17 @@ class Driver(object):
         if not self.connected:
             return {}
 
+        connection_info = {
+            "ip_address": self.host if self.web_client is not None else "",
+            "device_id": self.mb_device_id if self.mb_client is not None else 0,
+        }
         gripper_spec = {
             "max_stroke": self.module_parameters["max_phys_stroke"] / 1000,
             "max_speed": self.module_parameters["max_vel"] / 1000,
             "max_force": self.module_parameters["max_grp_force"] / 1000,
             "serial_number": self.module_parameters["serial_no_txt"],
             "firmware_version": self.module_parameters["sw_version_txt"],
+            **connection_info,
         }
         return gripper_spec
 

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -104,7 +104,7 @@ class Driver(object):
         self.mb_client: NonExclusiveSerialClient | None = None
         self.mb_device_id: int = 0
         self.web_client: Client | None = None
-        self.host: str = "0.0.0.0"
+        self.host: str = ""
         self.port: int = 80
         self.mb_client_lock: Lock = Lock()
         self.web_client_lock: Lock = Lock()
@@ -412,8 +412,8 @@ class Driver(object):
             return {}
 
         connection_info = {
-            "ip_address": self.host if self.web_client is not None else "",
-            "device_id": self.mb_device_id if self.mb_client is not None else 0,
+            "ip_address": self.host,
+            "device_id": self.mb_device_id,
         }
         gripper_spec = {
             "max_stroke": self.module_parameters["max_phys_stroke"] / 1000,

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -548,7 +548,7 @@ def test_driver_offers_waiting_until_error():
 
 
 @skip_without_gripper
-def test_driver_offers_showing_gripper_specification():
+def test_driver_offers_showing_gripper_specification_modbus():
     driver = Driver()
 
     # Without driver connected
@@ -556,17 +556,42 @@ def test_driver_offers_showing_gripper_specification():
 
     # With driver connected
     driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
-
     spec = driver.show_gripper_specification()
     assert spec != {}
-    params = [
+    assert spec["device_id"] == 12
+    assert spec["ip_address"] == ""
+    for param in [
         "max_stroke",
         "max_speed",
         "max_force",
         "serial_number",
         "firmware_version",
-    ]
-    for param in params:
+    ]:
+        assert param in spec
+
+    driver.disconnect()
+
+
+@skip_without_gripper
+def test_driver_offers_showing_gripper_specification_ethernet():
+    driver = Driver()
+
+    # Without driver connected
+    assert driver.show_gripper_specification() == {}
+
+    # With driver connected
+    driver.connect(host="0.0.0.0", port=8000)
+    spec = driver.show_gripper_specification()
+    assert spec != {}
+    assert spec["ip_address"] == "0.0.0.0"
+    assert spec["device_id"] == 0
+    for param in [
+        "max_stroke",
+        "max_speed",
+        "max_force",
+        "serial_number",
+        "firmware_version",
+    ]:
         assert param in spec
 
     driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -555,30 +555,33 @@ def test_driver_offers_showing_gripper_specification():
         "max_force",
         "serial_number",
         "firmware_version",
+        "device_id",
+        "ip_address",
     ]
 
-    # Test Modbus connection
+    # Not connected
     driver = Driver()
     assert driver.show_gripper_specification() == {}
 
+    # Modbus connection
     driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
     spec = driver.show_gripper_specification()
     assert spec != {}
-    assert spec["device_id"] == 12
-    assert spec["ip_address"] == ""
     for key in expected_keys:
         assert key in spec
+
+    assert spec["device_id"] == 12
+    assert spec["ip_address"] == ""
     driver.disconnect()
 
-    # Test Ethernet connection
+    # Ethernet connection
     driver = Driver()
-    assert driver.show_gripper_specification() == {}
-
     driver.connect(host="0.0.0.0", port=8000)
     spec = driver.show_gripper_specification()
     assert spec != {}
-    assert spec["device_id"] == 0
-    assert spec["ip_address"] == "0.0.0.0"
     for key in expected_keys:
         assert key in spec
+
+    assert spec["device_id"] == 0
+    assert spec["ip_address"] == "0.0.0.0"
     driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -548,50 +548,37 @@ def test_driver_offers_waiting_until_error():
 
 
 @skip_without_gripper
-def test_driver_offers_showing_gripper_specification_modbus():
-    driver = Driver()
+def test_driver_offers_showing_gripper_specification():
+    expected_keys = [
+        "max_stroke",
+        "max_speed",
+        "max_force",
+        "serial_number",
+        "firmware_version",
+    ]
 
-    # Without driver connected
+    # Test Modbus connection
+    driver = Driver()
     assert driver.show_gripper_specification() == {}
 
-    # With driver connected
     driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
     spec = driver.show_gripper_specification()
     assert spec != {}
     assert spec["device_id"] == 12
     assert spec["ip_address"] == ""
-    for param in [
-        "max_stroke",
-        "max_speed",
-        "max_force",
-        "serial_number",
-        "firmware_version",
-    ]:
-        assert param in spec
-
+    for key in expected_keys:
+        assert key in spec
     driver.disconnect()
 
-
-@skip_without_gripper
-def test_driver_offers_showing_gripper_specification_ethernet():
+    # Test Ethernet connection
     driver = Driver()
-
-    # Without driver connected
     assert driver.show_gripper_specification() == {}
 
-    # With driver connected
     driver.connect(host="0.0.0.0", port=8000)
     spec = driver.show_gripper_specification()
     assert spec != {}
-    assert spec["ip_address"] == "0.0.0.0"
     assert spec["device_id"] == 0
-    for param in [
-        "max_stroke",
-        "max_speed",
-        "max_force",
-        "serial_number",
-        "firmware_version",
-    ]:
-        assert param in spec
-
+    assert spec["ip_address"] == "0.0.0.0"
+    for key in expected_keys:
+        assert key in spec
     driver.disconnect()


### PR DESCRIPTION
Enhance show_gripper_specification() by adding Modbus Device ID or IP-Address in specification  