### PR TITLE
Rename `show_gripper_specification`

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -253,7 +253,7 @@ class Driver(Node):
             self.gripper_services.append(
                 self.create_service(
                     ShowGripperSpecification,
-                    f"~/{gripper['gripper_id']}/show_gripper_specification",
+                    f"~/{gripper['gripper_id']}/show_specification",
                     partial(self._show_gripper_specification_cb, gripper=gripper),
                 )
             )
@@ -471,8 +471,8 @@ class Driver(Node):
         response: ShowGripperSpecification.Response,
         gripper: Gripper,
     ):
-        self.get_logger().info("---> Show Specification")
-        spec = gripper["driver"].show_gripper_specification()
+        self.get_logger().debug("---> Show specification")
+        spec = gripper["driver"].show_specification()
         if not spec:
             response.success = False
             response.message = gripper["driver"].get_status_diagnostics()

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -49,7 +49,7 @@ def test_driver_advertises_state_depending_services(lifecycle_interface):
         "move_to_absolute_position",
         "grip",
         "release",
-        "show_gripper_specification",
+        "show_specification",
     ]
     until_change_takes_effect = 0.1
 
@@ -308,7 +308,7 @@ def test_driver_implements_show_specification(lifecycle_interface):
     for gripper in driver.list_grippers():
         client = node.create_client(
             ShowGripperSpecification,
-            f"/schunk/driver/{gripper}/show_gripper_specification",
+            f"/schunk/driver/{gripper}/show_specification",
         )
         assert client.wait_for_service(timeout_sec=2), f"gripper: {gripper}"
         future = client.call_async(ShowGripperSpecification.Request())

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -407,7 +407,7 @@ class Driver(object):
                 return False
             return check()
 
-    def show_gripper_specification(self) -> dict[str, float | str]:
+    def show_specification(self) -> dict[str, float | str]:
         if not self.connected:
             return {}
 
@@ -415,7 +415,7 @@ class Driver(object):
             "ip_address": self.host,
             "device_id": self.mb_device_id,
         }
-        gripper_spec = {
+        spec = {
             "max_stroke": self.module_parameters["max_phys_stroke"] / 1000,
             "max_speed": self.module_parameters["max_vel"] / 1000,
             "max_force": self.module_parameters["max_grp_force"] / 1000,
@@ -423,7 +423,7 @@ class Driver(object):
             "firmware_version": self.module_parameters["sw_version_txt"],
             **connection_info,
         }
-        return gripper_spec
+        return spec
 
     def estimate_duration(
         self,

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -561,11 +561,11 @@ def test_driver_offers_showing_gripper_specification():
 
     # Not connected
     driver = Driver()
-    assert driver.show_gripper_specification() == {}
+    assert driver.show_specification() == {}
 
     # Modbus connection
     driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
-    spec = driver.show_gripper_specification()
+    spec = driver.show_specification()
     assert spec != {}
     for key in expected_keys:
         assert key in spec
@@ -577,7 +577,7 @@ def test_driver_offers_showing_gripper_specification():
     # Ethernet connection
     driver = Driver()
     driver.connect(host="0.0.0.0", port=8000)
-    spec = driver.show_gripper_specification()
+    spec = driver.show_specification()
     assert spec != {}
     for key in expected_keys:
         assert key in spec


### PR DESCRIPTION
That's now shorter and more concise.
