### PR TITLE
Resolve default gripper initialization with device_id 12 on start

### DIFF
--- a/schunk_gripper_driver/launch/driver.launch.py
+++ b/schunk_gripper_driver/launch/driver.launch.py
@@ -40,13 +40,13 @@ device_id = DeclareLaunchArgument(
     description="The gripper's Modbus device id",
 )
 
-initial_gripper = DeclareLaunchArgument(
-    "initial_gripper",
-    default_value="true",
-    description="Use the default gripper configuration",
+start_empty = DeclareLaunchArgument(
+    "start_empty",
+    default_value="false",
+    description="Whether to drop gripper-specific launch arguments",
 )
 
-args = [host, port, serial_port, device_id, initial_gripper]
+args = [host, port, serial_port, device_id, start_empty]
 
 
 def generate_launch_description():
@@ -63,7 +63,7 @@ def generate_launch_description():
                     {"port": LaunchConfiguration("port")},
                     {"serial_port": LaunchConfiguration("serial_port")},
                     {"device_id": LaunchConfiguration("device_id")},
-                    {"initial_gripper": LaunchConfiguration("initial_gripper")},
+                    {"start_empty": LaunchConfiguration("start_empty")},
                 ],
                 respawn=True,
                 output="both",

--- a/schunk_gripper_driver/launch/driver.launch.py
+++ b/schunk_gripper_driver/launch/driver.launch.py
@@ -39,7 +39,14 @@ device_id = DeclareLaunchArgument(
     default_value="12",
     description="The gripper's Modbus device id",
 )
-args = [host, port, serial_port, device_id]
+
+create_default_gripper = DeclareLaunchArgument(
+    "create_default_gripper",
+    default_value="true",
+    description="Use the default gripper configuration",
+)
+
+args = [host, port, serial_port, device_id, create_default_gripper]
 
 
 def generate_launch_description():
@@ -56,6 +63,11 @@ def generate_launch_description():
                     {"port": LaunchConfiguration("port")},
                     {"serial_port": LaunchConfiguration("serial_port")},
                     {"device_id": LaunchConfiguration("device_id")},
+                    {
+                        "create_default_gripper": LaunchConfiguration(
+                            "create_default_gripper"
+                        )
+                    },
                 ],
                 respawn=True,
                 output="both",

--- a/schunk_gripper_driver/launch/driver.launch.py
+++ b/schunk_gripper_driver/launch/driver.launch.py
@@ -40,13 +40,13 @@ device_id = DeclareLaunchArgument(
     description="The gripper's Modbus device id",
 )
 
-create_default_gripper = DeclareLaunchArgument(
-    "create_default_gripper",
+initial_gripper = DeclareLaunchArgument(
+    "initial_gripper",
     default_value="true",
     description="Use the default gripper configuration",
 )
 
-args = [host, port, serial_port, device_id, create_default_gripper]
+args = [host, port, serial_port, device_id, initial_gripper]
 
 
 def generate_launch_description():
@@ -63,11 +63,7 @@ def generate_launch_description():
                     {"port": LaunchConfiguration("port")},
                     {"serial_port": LaunchConfiguration("serial_port")},
                     {"device_id": LaunchConfiguration("device_id")},
-                    {
-                        "create_default_gripper": LaunchConfiguration(
-                            "create_default_gripper"
-                        )
-                    },
+                    {"initial_gripper": LaunchConfiguration("initial_gripper")},
                 ],
                 respawn=True,
                 output="both",

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -69,18 +69,22 @@ class Driver(Node):
         self.declare_parameter("serial_port", "/dev/ttyUSB0")
         self.declare_parameter("device_id", 12)
         self.declare_parameter("log_level", "INFO")
+        self.declare_parameter("create_default_gripper", True)
 
         self.scheduler: Scheduler = Scheduler()
         self.grippers: list[Gripper] = []
-        gripper: Gripper = {
-            "host": self.get_parameter("host").value,
-            "port": self.get_parameter("port").value,
-            "serial_port": self.get_parameter("serial_port").value,
-            "device_id": self.get_parameter("device_id").value,
-            "driver": GripperDriver(),
-            "gripper_id": "",
-        }
-        self.grippers.append(gripper)
+
+        create_default = self.get_parameter("create_default_gripper").value
+        if create_default:
+            gripper: Gripper = {
+                "host": self.get_parameter("host").value,
+                "port": self.get_parameter("port").value,
+                "serial_port": self.get_parameter("serial_port").value,
+                "device_id": self.get_parameter("device_id").value,
+                "driver": GripperDriver(),
+                "gripper_id": "",
+            }
+            self.grippers.append(gripper)
         self.gripper_services: list[Service] = []
         self.joint_state_publishers: dict[str, Publisher] = {}
         self.gripper_state_publishers: dict[str, Publisher] = {}

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -69,13 +69,13 @@ class Driver(Node):
         self.declare_parameter("serial_port", "/dev/ttyUSB0")
         self.declare_parameter("device_id", 12)
         self.declare_parameter("log_level", "INFO")
-        self.declare_parameter("initial_gripper", True)
+        self.declare_parameter("start_empty", False)
 
         self.scheduler: Scheduler = Scheduler()
         self.grippers: list[Gripper] = []
 
-        initial_gripper = self.get_parameter("initial_gripper").value
-        if initial_gripper:
+        start_empty = self.get_parameter("start_empty").value
+        if not start_empty:
             gripper: Gripper = {
                 "host": self.get_parameter("host").value,
                 "port": self.get_parameter("port").value,

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -69,13 +69,13 @@ class Driver(Node):
         self.declare_parameter("serial_port", "/dev/ttyUSB0")
         self.declare_parameter("device_id", 12)
         self.declare_parameter("log_level", "INFO")
-        self.declare_parameter("create_default_gripper", True)
+        self.declare_parameter("initial_gripper", True)
 
         self.scheduler: Scheduler = Scheduler()
         self.grippers: list[Gripper] = []
 
-        create_default = self.get_parameter("create_default_gripper").value
-        if create_default:
+        initial_gripper = self.get_parameter("initial_gripper").value
+        if initial_gripper:
             gripper: Gripper = {
                 "host": self.get_parameter("host").value,
                 "port": self.get_parameter("port").value,

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
@@ -63,7 +63,7 @@ def ros2():
 
 @launch_pytest.fixture(scope="module")
 def driver(request, ros2):
-    create_default_gripper = getattr(request.module, "create_default_gripper", True)
+    initial_gripper = getattr(request.module, "initial_gripper", True)
     setup = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
@@ -74,9 +74,7 @@ def driver(request, ros2):
                 ]
             )
         ),
-        launch_arguments={
-            "create_default_gripper": str(create_default_gripper).lower()
-        }.items(),
+        launch_arguments={"initial_gripper": str(initial_gripper).lower()}.items(),
     )
     return LaunchDescription([setup, launch_pytest.actions.ReadyToTest()])
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
@@ -63,7 +63,7 @@ def ros2():
 
 @launch_pytest.fixture(scope="module")
 def driver(request, ros2):
-    initial_gripper = getattr(request.module, "initial_gripper", True)
+    start_empty = getattr(request.module, "start_empty", False)
     setup = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
@@ -74,7 +74,7 @@ def driver(request, ros2):
                 ]
             )
         ),
-        launch_arguments={"initial_gripper": str(initial_gripper).lower()}.items(),
+        launch_arguments={"start_empty": str(start_empty).lower()}.items(),
     )
     return LaunchDescription([setup, launch_pytest.actions.ReadyToTest()])
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
@@ -24,6 +24,7 @@ import launch_pytest
 from lifecycle_msgs.srv import ChangeState, GetState
 from rcl_interfaces.srv import SetParameters
 from schunk_gripper_interfaces.srv import ListGrippers  # type: ignore [attr-defined]
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 from rclpy.node import Node
 import os
@@ -61,15 +62,21 @@ def ros2():
 
 
 @launch_pytest.fixture(scope="module")
-def driver(ros2):
+def driver(request, ros2):
+    create_default_gripper = getattr(request.module, "create_default_gripper", True)
     setup = IncludeLaunchDescription(
-        PathJoinSubstitution(
-            [
-                FindPackageShare("schunk_gripper_driver"),
-                "launch",
-                "driver.launch.py",
-            ]
-        )
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("schunk_gripper_driver"),
+                    "launch",
+                    "driver.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "create_default_gripper": str(create_default_gripper).lower()
+        }.items(),
     )
     return LaunchDescription([setup, launch_pytest.actions.ReadyToTest()])
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_launch.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_launch.py
@@ -30,7 +30,7 @@ def test_normal_startup_works(driver):
 
 
 # The driver is started without default gripper
-create_default_gripper = False
+initial_gripper = False
 
 
 def test_show_configuration_is_empty_without_default_gripper(driver):

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_launch.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_launch.py
@@ -29,12 +29,11 @@ def test_normal_startup_works(driver):
     assert client.wait_for_service(timeout_sec=2)
 
 
-# The driver is started without default gripper
-initial_gripper = False
+start_empty = True
 
 
-def test_show_configuration_is_empty_without_default_gripper(driver):
-    node = Node("test_show_configuration_node")
+def test_driver_can_start_without_initial_gripper(driver):
+    node = Node("test_without_initial_gripper")
 
     client = node.create_client(ShowConfiguration, "/schunk/driver/show_configuration")
 
@@ -45,6 +44,6 @@ def test_show_configuration_is_empty_without_default_gripper(driver):
 
     rclpy.spin_until_future_complete(node, future, timeout_sec=2.0)
     response = future.result()
-    assert response.configuration == [], "Expected empty configuration list"
+    assert response.configuration == []
 
     node.destroy_node()

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
@@ -26,7 +26,7 @@ DRIVER_PARAMETERS = [
     "serial_port",
     "device_id",
     "log_level",
-    "create_default_gripper",
+    "initial_gripper",
 ]
 
 
@@ -84,7 +84,7 @@ def test_driver_has_expected_parameters_after_startup(driver):
             ),
         ),
         Parameter(
-            name="create_default_gripper",
+            name="initial_gripper",
             value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=True),
         ),
     ]
@@ -140,7 +140,7 @@ def test_driver_supports_setting_parameters(driver):
             ),
         ),
         Parameter(
-            name="create_default_gripper",
+            name="initial_gripper",
             value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=False),
         ),
     ]

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
@@ -20,7 +20,14 @@ from rcl_interfaces.msg import Parameter, ParameterValue, ParameterType
 from schunk_gripper_library.utility import skip_without_gripper
 
 
-DRIVER_PARAMETERS = ["host", "port", "serial_port", "device_id", "log_level"]
+DRIVER_PARAMETERS = [
+    "host",
+    "port",
+    "serial_port",
+    "device_id",
+    "log_level",
+    "create_default_gripper",
+]
 
 
 @skip_without_gripper
@@ -76,6 +83,10 @@ def test_driver_has_expected_parameters_after_startup(driver):
                 type=ParameterType.PARAMETER_STRING, string_value="INFO"
             ),
         ),
+        Parameter(
+            name="create_default_gripper",
+            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=True),
+        ),
     ]
     future = get_params_client.call_async(
         GetParameters.Request(names=DRIVER_PARAMETERS)
@@ -127,6 +138,10 @@ def test_driver_supports_setting_parameters(driver):
             value=ParameterValue(
                 type=ParameterType.PARAMETER_STRING, string_value="DEBUG"
             ),
+        ),
+        Parameter(
+            name="create_default_gripper",
+            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=False),
         ),
     ]
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
@@ -26,7 +26,7 @@ DRIVER_PARAMETERS = [
     "serial_port",
     "device_id",
     "log_level",
-    "initial_gripper",
+    "start_empty",
 ]
 
 
@@ -84,8 +84,8 @@ def test_driver_has_expected_parameters_after_startup(driver):
             ),
         ),
         Parameter(
-            name="initial_gripper",
-            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=True),
+            name="start_empty",
+            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=False),
         ),
     ]
     future = get_params_client.call_async(
@@ -140,8 +140,8 @@ def test_driver_supports_setting_parameters(driver):
             ),
         ),
         Parameter(
-            name="initial_gripper",
-            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=False),
+            name="start_empty",
+            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=True),
         ),
     ]
 


### PR DESCRIPTION
Currently, when starting the driver with: ros2 launch schunk_gripper_driver driver.launch.py
A default gripper is created using serial port /dev/ttyUSB0 and device_id 12. 
This causes issues when:
Adding another gripper with device_id 12, which doesn’t override the default and causes configuration failure.
Adding a gripper with a different device_id (e.g. 14), which also fails because the driver still tries to connect to the default gripper with device_id 12.

- [x] Add additional parameter during launch
- [x] Implement the test to verify 

---
Resolves #51 