### PR TITLE
Add mechanism to save config files

### DIFF
--- a/schunk_gripper_driver/launch/driver.launch.py
+++ b/schunk_gripper_driver/launch/driver.launch.py
@@ -59,6 +59,7 @@ def generate_launch_description():
                 ],
                 respawn=True,
                 output="both",
+                # arguments=['--ros-args', '--log-level', 'DEBUG'],
             )
         ]
     )

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -45,6 +45,8 @@ from schunk_gripper_library.utility import Scheduler
 from typing import TypedDict
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rcl_interfaces.msg import SetParametersResult
+from pathlib import Path
+import tempfile
 
 
 class Gripper(TypedDict):
@@ -128,6 +130,28 @@ class Driver(Node):
             cfg.device_id = gripper["device_id"]
             configuration.append(cfg)
         return configuration
+
+    def save_configuration(self, location: str = "/tmp/schunk_gripper") -> bool:
+        if not self.show_configuration():
+            return False
+
+        path = Path(location)
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            with tempfile.TemporaryFile(dir=path):
+                pass
+        except Exception:
+            return False
+
+        return True
+
+    def load_previous_configuration(
+        self, location: str = "/tmp/schunk_gripper"
+    ) -> bool:
+        path = Path(location)
+        if not path.is_dir():
+            return False
+        return True
 
     def add_gripper(
         self, host: str = "", port: int = 0, serial_port: str = "", device_id: int = 0

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -97,6 +97,14 @@ class Driver(Node):
         self.show_configuration_srv = self.create_service(
             ShowConfiguration, "~/show_configuration", self._show_configuration_cb
         )
+        self.save_configuration_srv = self.create_service(
+            Trigger, "~/save_configuration", self._save_configuration_cb
+        )
+        self.load_previous_configuration_srv = self.create_service(
+            Trigger,
+            "~/load_previous_configuration",
+            self._load_previous_configuration_cb,
+        )
         self.add_on_set_parameters_callback(self._param_cb)
 
         # For concurrently running publishers
@@ -415,6 +423,14 @@ class Driver(Node):
         self.show_configuration_srv = self.create_service(
             ShowConfiguration, "~/show_configuration", self._show_configuration_cb
         )
+        self.save_configuration_srv = self.create_service(
+            Trigger, "~/save_configuration", self._save_configuration_cb
+        )
+        self.load_previous_configuration_srv = self.create_service(
+            Trigger,
+            "~/load_previous_configuration",
+            self._load_previous_configuration_cb,
+        )
 
         return TransitionCallbackReturn.SUCCESS
 
@@ -539,6 +555,18 @@ class Driver(Node):
         self, request: ShowConfiguration.Request, response: ShowConfiguration.Response
     ):
         response.configuration = self.show_configuration()
+        return response
+
+    def _save_configuration_cb(
+        self, request: Trigger.Request, response: Trigger.Response
+    ):
+        response.success = self.save_configuration()
+        return response
+
+    def _load_previous_configuration_cb(
+        self, request: Trigger.Request, response: Trigger.Response
+    ):
+        response.success = self.load_previous_configuration()
         return response
 
     def _list_grippers_cb(

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -133,7 +133,7 @@ class Driver(Node):
             configuration.append(cfg)
         return configuration
 
-    def save_configuration(self, location: str = "/tmp/schunk_gripper") -> bool:
+    def save_configuration(self, location: str = "/var/tmp/schunk_gripper") -> bool:
         LOG_NS = "Save configuration:"
 
         if not self.show_configuration():
@@ -162,7 +162,7 @@ class Driver(Node):
         return True
 
     def load_previous_configuration(
-        self, location: str = "/tmp/schunk_gripper"
+        self, location: str = "/var/tmp/schunk_gripper"
     ) -> bool:
         LOG_NS = "Load configuration:"
 

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -208,21 +208,35 @@ class Driver(Node):
     def add_gripper(
         self, host: str = "", port: int = 0, serial_port: str = "", device_id: int = 0
     ) -> bool:
+        LOG_NS = "Add gripper:"
         if not any([host, port, serial_port, device_id]):
+            self.get_logger().debug(f"{LOG_NS} empty gripper")
             return False
         if (host and not port) or (port and not host):
+            self.get_logger().debug(
+                f"{LOG_NS} missing host or port."
+                " You need to specify both or none of them"
+            )
             return False
         if (serial_port and not device_id) or (device_id and not serial_port):
+            self.get_logger().debug(
+                f"{LOG_NS} missing serial_port or device_id."
+                " You need to specify both or none of them"
+            )
             return False
         for gripper in self.grippers:
             if host:
                 if host == gripper["host"] and port == gripper["port"]:
+                    self.get_logger().debug(f"{LOG_NS} host and port already used")
                     return False
             else:
                 if (
                     serial_port == gripper["serial_port"]
                     and device_id == gripper["device_id"]
                 ):
+                    self.get_logger().debug(
+                        f"{LOG_NS} serial_port and device_id already used"
+                    )
                     return False
         self.grippers.append(
             {

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -164,11 +164,21 @@ class Driver(Node):
         if not config_file.exists():
             return False
 
-        with open(config_file, "r") as f:
-            content = json.load(f)
+        try:
+            with open(config_file, "r") as f:
+                try:
+                    content = json.load(f)
+                except json.JSONDecodeError:
+                    return False
+        except Exception:
+            return False
 
-        for entry in content:
-            self.add_gripper(**entry)
+        for gripper in content:
+            try:
+                if not self.add_gripper(**gripper):
+                    return False
+            except TypeError:
+                return False
         return True
 
     def add_gripper(

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_configuration.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_configuration.py
@@ -76,7 +76,7 @@ def test_driver_rejects_loading_invalid_configuration(ros2):
         ],  # valid entries, but nested
     ]
 
-    location = Path("/tmp/schunk_gripper")
+    location = Path("/var/tmp/schunk_gripper")
 
     for config in invalid_configurations:
         with open(location.joinpath("configuration.json"), "w") as f:
@@ -90,7 +90,7 @@ def test_driver_rejects_loading_incorrectly_formatted_configuration(ros2):
     driver = Driver("driver")
     driver.reset_grippers()
 
-    location = Path("/tmp/schunk_gripper")
+    location = Path("/var/tmp/schunk_gripper")
 
     # With nonsense content
     with open(location.joinpath("configuration.json"), "w") as f:
@@ -151,7 +151,7 @@ def test_driver_keeps_current_grippers_when_loading_invalid_configuration():
 
     # Store invalid parameters
     config = {"invalid_parameter": -1}
-    location = Path("/tmp/schunk_gripper")
+    location = Path("/var/tmp/schunk_gripper")
     with open(location.joinpath("configuration.json"), "w") as f:
         json.dump([config], f)
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_configuration.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_configuration.py
@@ -1,0 +1,53 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from schunk_gripper_driver.driver import Driver
+
+
+def test_driver_offers_saving_gripper_configuration(ros2):
+    driver = Driver("driver")
+
+    # When empty
+    driver.reset_grippers()
+    assert not driver.save_configuration()
+
+    # Non-writable locations
+    invalid_locations = ["/", "/dev"]
+    for location in invalid_locations:
+        assert not driver.save_configuration(location=location), f"location: {location}"
+
+    # When filled
+    config = {"host": "1.2.3.4", "port": 77, "serial_port": "abc", "device_id": 42}
+    driver.add_gripper(**config)
+    assert driver.save_configuration()
+
+
+def test_driver_offers_loading_previous_gripper_configuration(ros2):
+    driver = Driver("driver")
+    driver.reset_grippers()
+
+    # Nothing previously saved
+    assert not driver.load_previous_configuration(location="non-existent")
+    assert len(driver.grippers) == 0
+
+    # With saved configuration
+    config = {"host": "1.2.3.4", "port": 77, "serial_port": "abc", "device_id": 42}
+    driver.add_gripper(**config)
+    assert driver.save_configuration()
+    driver.reset_grippers()
+
+    assert driver.load_previous_configuration()
+    assert len(driver.grippers) == 1
+    for key, value in config.items():
+        assert driver.grippers[0][key] == value


### PR DESCRIPTION
## Background
It would be nice to save the grippers' configuration and load that on the next startup. This feature targets automation where the configuration doesn't change after an initial setup, and where work needs to be resumed every morning.

**Possible interface**:
- `save_configuration()`
- `load_previous_configuration()`

## Steps
- [x] Find good location where to safe driver-specific config files
- [x] Implement the save method
- [x] Implement the load method
- [x] Add ROS2 service interfaces