### PR TITLE
Refactor gripper commands to use generic options field for feature flexibility

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -687,16 +687,20 @@ class Driver(Node):
         self.get_logger().debug("---> Move to absolute position")
         position = int(request.position * 1e6)
         velocity = int(request.velocity * 1e6)
+
+        options_dict = {kv.feature: kv.value for kv in request.options}
+        use_gpe = options_dict.get("use_gpe", False)
+
         if self.needs_synchronize(gripper):
             response.success = gripper["driver"].move_to_absolute_position(
                 position=position,
                 velocity=velocity,
-                use_gpe=request.use_gpe,
+                use_gpe=use_gpe,
                 scheduler=self.scheduler,
             )
         else:
             response.success = gripper["driver"].move_to_absolute_position(
-                position=position, velocity=velocity, use_gpe=request.use_gpe
+                position=position, velocity=velocity, use_gpe=use_gpe
             )
         response.message = gripper["driver"].get_status_diagnostics()
         return response

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -28,6 +28,7 @@ from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
 )
 from schunk_gripper_interfaces.msg import (  # type: ignore [attr-defined]
     Gripper as GripperConfig,
+    KeyValue as KeyValue,
 )
 from rclpy.node import Node
 import rclpy
@@ -222,7 +223,7 @@ def test_driver_implements_move_to_absolute_position(lifecycle_interface):
             request = MoveToAbsolutePosition.Request()
             request.position = target["position"]
             request.velocity = target["velocity"]
-            request.use_gpe = target["use_gpe"]
+            request.options = [KeyValue(feature="use_gpe", value=target["use_gpe"])]
             future = client.call_async(request)
             rclpy.spin_until_future_complete(node, future, timeout_sec=3)
             assert future.result().success, f"{future.result().message}"

--- a/schunk_gripper_interfaces/CMakeLists.txt
+++ b/schunk_gripper_interfaces/CMakeLists.txt
@@ -22,6 +22,7 @@ rosidl_generate_interfaces(
     msg/Gripper.msg
     msg/GripperState.msg
     msg/GripperSpec.msg
+    msg/KeyValue.msg
   DEPENDENCIES
     std_msgs
 )

--- a/schunk_gripper_interfaces/msg/KeyValue.msg
+++ b/schunk_gripper_interfaces/msg/KeyValue.msg
@@ -1,0 +1,2 @@
+string feature  # Specific gripper feature
+bool value    # Value for the feature

--- a/schunk_gripper_interfaces/srv/MoveToAbsolutePosition.srv
+++ b/schunk_gripper_interfaces/srv/MoveToAbsolutePosition.srv
@@ -2,9 +2,7 @@ float32 position  # Absolute position in [m]
 
 float32 velocity  # Velocity in [m/s]
 
-bool use_gpe      # Whether to activate position maintenance after moving.
-                  # Will only be used when available in the gripper.
-                  # Defaults to False.
+KeyValue[] options # Specify the feature and value
 ---
 bool success
 string message


### PR DESCRIPTION
## Objective
This update improves the gripper command by customizing the service options based on the gripper variant:
For Instance:
If the gripper has no brake, the parameter `use_gpe` should be excluded since it’s not applicable.
If the gripper is EGK variant,  the service_request_details of the grip command must include the gripping `velocity`. (Soft Grip)

## Problem Statement
The ROS 2 service currently includes all possible input fields including optional ones regardless of whether the connected gripper model supports them. This results in confusion for users and unclear interfaces, especially when some grippers do not support specific features.

## Possible solutions
1. Separate `.srv` Files Per Feature (Same Package)
Create different `.srv` files per gripper capability within the same ROS 2 package.
Implications:
•	Requires maintaining multiple versions of the same service with minor differences.
•	Easier to implement within a single codebase.
•	Service type visibility (`ros2 interface show`) still reveals all service definitions in the package, even for unsupported devices.
•	Provides decent clarity at the service level but does not fully conceal optional fields from being discovered.

2. Separate `.srv` Files in Separate Packages
Maintain feature specific service definitions in dedicated packages, installed only with supported hardware.
Implications:
•	Ensures can users can only see the services relevant to their setup.
•	Requires managing multiple ROS packages.
•	Provides true hiding of unsupported service fields and types.
•	Most scalable and cleanest option for hiding the unnecessary feature.

3. Generic Options Field in a Single Service
Replace optional fields with a generic field such as a `map<string, string>` or `features` field that can be parsed dynamically by the service.
Implications:
•	Only one `.srv` file to maintain.
•	No type safety or autocomplete (everything is a key-value pair).
•	Reduces clarity of the feature.
•	Offers maximum flexibility and avoids service duplication.


4. Capability Discovery Service (`GetCapabilities`)
Introduce a separate service (e.g., `Getcapabilities`) that returns supported features per gripper.
Implications:
•	Does not prevent the full `.srv` definition from being exposed.
•	Shifts responsibility to the users to check what features are supported.


---
Addresses: #54 