### PR TITLE
Improve handling of startup parameters

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -64,15 +64,18 @@ class Driver(Node):
 
     def __init__(self, node_name: str, **kwargs):
         super().__init__(node_name, **kwargs)
-        self.declare_parameter("host", "")
-        self.declare_parameter("port", 80)
-        self.declare_parameter("serial_port", "/dev/ttyUSB0")
-        self.declare_parameter("device_id", 12)
-        self.declare_parameter("log_level", "INFO")
-        self.declare_parameter("start_empty", False)
-
-        self.scheduler: Scheduler = Scheduler()
         self.grippers: list[Gripper] = []
+
+        # Initialization parameters
+        self.init_parameters = {
+            "host": "",
+            "port": 80,
+            "serial_port": "/dev/ttyUSB0",
+            "device_id": 12,
+            "start_empty": False,
+        }
+        for name, default_value in self.init_parameters.items():
+            self.declare_parameter(name, default_value)
 
         start_empty = self.get_parameter("start_empty").value
         if not start_empty:
@@ -85,6 +88,15 @@ class Driver(Node):
                 "gripper_id": "",
             }
             self.grippers.append(gripper)
+
+        # Clean up initialization parameters
+        for name in self.init_parameters.keys():
+            self.undeclare_parameter(name)
+
+        # Node parameters
+        self.declare_parameter("log_level", "INFO")
+
+        self.scheduler: Scheduler = Scheduler()
         self.gripper_services: list[Service] = []
         self.joint_state_publishers: dict[str, Publisher] = {}
         self.gripper_state_publishers: dict[str, Publisher] = {}

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
@@ -21,12 +21,7 @@ from schunk_gripper_library.utility import skip_without_gripper
 
 
 DRIVER_PARAMETERS = [
-    "host",
-    "port",
-    "serial_port",
-    "device_id",
     "log_level",
-    "start_empty",
 ]
 
 
@@ -56,36 +51,10 @@ def test_driver_has_expected_parameters_after_startup(driver):
 
     default_parameters = [
         Parameter(
-            name="host",
-            value=ParameterValue(type=ParameterType.PARAMETER_STRING, string_value=""),
-        ),
-        Parameter(
-            name="port",
-            value=ParameterValue(
-                type=ParameterType.PARAMETER_INTEGER, integer_value=80
-            ),
-        ),
-        Parameter(
-            name="serial_port",
-            value=ParameterValue(
-                type=ParameterType.PARAMETER_STRING, string_value="/dev/ttyUSB0"
-            ),
-        ),
-        Parameter(
-            name="device_id",
-            value=ParameterValue(
-                type=ParameterType.PARAMETER_INTEGER, integer_value=12
-            ),
-        ),
-        Parameter(
             name="log_level",
             value=ParameterValue(
                 type=ParameterType.PARAMETER_STRING, string_value="INFO"
             ),
-        ),
-        Parameter(
-            name="start_empty",
-            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=False),
         ),
     ]
     future = get_params_client.call_async(
@@ -110,38 +79,10 @@ def test_driver_supports_setting_parameters(driver):
 
     parameters = [
         Parameter(
-            name="host",
-            value=ParameterValue(
-                type=ParameterType.PARAMETER_STRING, string_value="0.0.0.0"
-            ),
-        ),
-        Parameter(
-            name="port",
-            value=ParameterValue(
-                type=ParameterType.PARAMETER_INTEGER, integer_value=1234
-            ),
-        ),
-        Parameter(
-            name="serial_port",
-            value=ParameterValue(
-                type=ParameterType.PARAMETER_STRING, string_value="/dev/serial-port"
-            ),
-        ),
-        Parameter(
-            name="device_id",
-            value=ParameterValue(
-                type=ParameterType.PARAMETER_INTEGER, integer_value=123
-            ),
-        ),
-        Parameter(
             name="log_level",
             value=ParameterValue(
                 type=ParameterType.PARAMETER_STRING, string_value="DEBUG"
             ),
-        ),
-        Parameter(
-            name="start_empty",
-            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=True),
         ),
     ]
 


### PR DESCRIPTION
## Background
We currently have gripper-specific initial connection parameters that aren't used later on. This is somewhat confusing.

## Steps
- [x] Hide startup-only parameters after initialization