### PR TITLE
Add a reconnection mechanism

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -32,10 +32,11 @@ from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
 from schunk_gripper_interfaces.msg import (  # type: ignore [attr-defined]
     Gripper as GripperConfig,
     GripperState,
+    ConnectionState,
 )
 from sensor_msgs.msg import JointState
 from std_srvs.srv import Trigger
-from threading import Lock, Timer as Countdown
+from threading import Lock, Thread, Event, Timer as Countdown
 from rclpy.service import Service
 from rclpy.publisher import Publisher
 from rclpy.timer import Timer
@@ -49,6 +50,7 @@ from pathlib import Path
 import tempfile
 import json
 from collections import OrderedDict
+import time
 
 
 class Gripper(TypedDict):
@@ -147,6 +149,20 @@ class Driver(Node):
             callback=partial(self._publish_gripper_states),
             callback_group=self.timers_cb_group,
         )
+
+        # Connection state
+        self.connection_state_publisher: Publisher = self.create_publisher(
+            msg_type=ConnectionState,
+            topic="~/connection_state",
+            qos_profile=1,
+            callback_group=self.publishers_cb_group,
+        )
+        self.connection_status_stop: Event = Event()
+        self.connection_status_period: float = 0.05  # sec
+        self.connection_status_thread: Thread = Thread(
+            target=self._publish_connection_state
+        )
+        self.connection_status_thread.start()
 
     def list_grippers(self) -> list[str]:
         devices = []
@@ -492,6 +508,8 @@ class Driver(Node):
         self.get_logger().debug("on_shutdown() is called.")
         self.joint_states_timer.cancel()
         self.gripper_states_timer.cancel()
+        self.connection_status_stop.set()
+        self.connection_status_thread.join()
 
         if state is None:
             return TransitionCallbackReturn.SUCCESS
@@ -588,6 +606,30 @@ class Driver(Node):
             with self.gripper_state_lock:
                 if gripper_id in self.gripper_state_publishers:
                     self.gripper_state_publishers[gripper_id].publish(msg)
+
+    def _publish_connection_state(self) -> None:
+        msg = ConnectionState()
+        msg.header.frame_id = self.get_name()
+        next_time = time.perf_counter()
+
+        while rclpy.ok() and not self.connection_status_stop.is_set():
+            now = time.perf_counter()
+            msg.header.stamp = self.get_clock().now().to_msg()
+            msg.grippers.clear()
+            msg.connected.clear()
+
+            for gripper in self.grippers:
+                id = gripper["gripper_id"]
+                driver = gripper["driver"]
+                if id:
+                    msg.grippers.append(id)
+                    msg.connected.append(driver.connected)
+
+            if now >= next_time:
+                self.connection_state_publisher.publish(msg)
+                next_time += self.connection_status_period
+            else:
+                time.sleep(max(0, next_time - now))
 
     # Service callbacks
     def _add_gripper_cb(

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -626,7 +626,12 @@ class Driver(Node):
                     msg.connected.append(driver.connected)
 
             if now >= next_time:
-                self.connection_state_publisher.publish(msg)
+                try:
+                    self.connection_state_publisher.publish(msg)
+
+                # Catch "publisher's context is invalid" on node destruction
+                except RuntimeError:
+                    break
                 next_time += self.connection_status_period
             else:
                 time.sleep(max(0, next_time - now))

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -513,6 +513,10 @@ def test_driver_uses_separate_callback_group_for_publishers(ros2: None):
         for handler in publisher.event_handlers:
             assert handler.callback_group != driver.default_callback_group
 
+    # Connection state
+    for handler in driver.connection_state_publisher.event_handlers:
+        assert handler.callback_group != driver.default_callback_group
+
     # Timers
     assert driver.joint_states_timer.callback_group != driver.default_callback_group
     assert driver.gripper_states_timer.callback_group != driver.default_callback_group
@@ -594,3 +598,11 @@ def test_driver_uses_separate_callback_group_for_gripper_services(ros2: None):
 
     driver.on_deactivate(state=None)
     driver.on_cleanup(state=None)
+
+
+def test_driver_uses_a_dedicated_thread_for_connection_status(ros2):
+    driver = Driver("driver")
+    assert driver.connection_status_thread.is_alive()
+
+    driver.on_shutdown(state=None)
+    assert not driver.connection_status_thread.is_alive()

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -62,35 +62,35 @@ def test_driver_advertises_state_depending_services(lifecycle_interface):
 
         # After startup -> unconfigured
         driver.check_state(State.PRIMARY_STATE_UNCONFIGURED)
-        assert driver.check(config_services, should_exist=True)
-        assert driver.check(list_grippers, should_exist=False)
+        assert driver.check(config_services, dtype="service", should_exist=True)
+        assert driver.check(list_grippers, dtype="service", should_exist=False)
 
         # After configure -> inactive
         driver.change_state(Transition.TRANSITION_CONFIGURE)
         time.sleep(until_change_takes_effect)
-        assert driver.check(list_grippers, should_exist=True)
-        assert driver.check(config_services, should_exist=False)
-        assert driver.check(gripper_services, should_exist=False)
+        assert driver.check(list_grippers, dtype="service", should_exist=True)
+        assert driver.check(config_services, dtype="service", should_exist=False)
+        assert driver.check(gripper_services, dtype="service", should_exist=False)
 
         # After activate -> active
         driver.change_state(Transition.TRANSITION_ACTIVATE)
         time.sleep(until_change_takes_effect)
-        assert driver.check(list_grippers, should_exist=True)
-        assert driver.check(config_services, should_exist=False)
-        assert driver.check(gripper_services, should_exist=True)
+        assert driver.check(list_grippers, dtype="service", should_exist=True)
+        assert driver.check(config_services, dtype="service", should_exist=False)
+        assert driver.check(gripper_services, dtype="service", should_exist=True)
 
         # After deactivate -> inactive
         driver.change_state(Transition.TRANSITION_DEACTIVATE)
         time.sleep(until_change_takes_effect)
-        assert driver.check(list_grippers, should_exist=True)
-        assert driver.check(config_services, should_exist=False)
-        assert driver.check(gripper_services, should_exist=False)
+        assert driver.check(list_grippers, dtype="service", should_exist=True)
+        assert driver.check(config_services, dtype="service", should_exist=False)
+        assert driver.check(gripper_services, dtype="service", should_exist=False)
 
         # After cleanup -> unconfigured
         driver.change_state(Transition.TRANSITION_CLEANUP)
         time.sleep(until_change_takes_effect)
-        assert driver.check(config_services, should_exist=True)
-        assert driver.check(list_grippers, should_exist=False)
+        assert driver.check(config_services, dtype="service", should_exist=True)
+        assert driver.check(list_grippers, dtype="service", should_exist=False)
 
 
 @skip_without_gripper

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_topics.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_topics.py
@@ -29,38 +29,28 @@ def test_driver_advertises_state_depending_topics(lifecycle_interface):
     gripper_topics = ["joint_states", "gripper_state"]
     until_change_takes_effect = 0.1
 
-    def exist(topics: list[str]) -> bool:
-        existing = driver.node.get_topic_names_and_types()
-        advertised = [i[0] for i in existing]
-        for gripper in driver.list_grippers():
-            for topic in topics:
-                if f"/schunk/driver/{gripper}/{topic}" not in advertised:
-                    return False
-        return True
-
-    for run in range(3):
+    for run in range(1):
 
         # After startup -> unconfigured
-        driver.check_state(State.PRIMARY_STATE_UNCONFIGURED)
+        assert driver.check_state(State.PRIMARY_STATE_UNCONFIGURED)
 
         # After configure -> inactive
         driver.change_state(Transition.TRANSITION_CONFIGURE)
         time.sleep(until_change_takes_effect)
-        assert not exist(gripper_topics)
+        assert driver.check(gripper_topics, dtype="topic", should_exist=False)
 
         # After activate -> active
         driver.change_state(Transition.TRANSITION_ACTIVATE)
         time.sleep(until_change_takes_effect)
-        assert exist(gripper_topics)
+        assert driver.check(gripper_topics, dtype="topic", should_exist=True)
 
         # After deactivate -> inactive
         driver.change_state(Transition.TRANSITION_DEACTIVATE)
         time.sleep(until_change_takes_effect)
-        assert not exist(gripper_topics)
+        assert driver.check(gripper_topics, dtype="topic", should_exist=False)
 
         # After cleanup -> unconfigured
         driver.change_state(Transition.TRANSITION_CLEANUP)
-        time.sleep(until_change_takes_effect)
 
 
 @skip_without_gripper

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_topics.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_topics.py
@@ -77,9 +77,9 @@ def test_driver_publishes_joint_states(lifecycle_interface):
             1,
         )
 
-    for _ in range(10):
-        rclpy.spin_once(driver.node)
-        time.sleep(0.1)
+    timeout = time.time() + 1.0
+    while time.time() < timeout and len(messages) == 0:
+        rclpy.spin_once(driver.node, timeout_sec=0.1)
 
     driver.change_state(Transition.TRANSITION_DEACTIVATE)
     driver.change_state(Transition.TRANSITION_CLEANUP)
@@ -131,9 +131,9 @@ def test_driver_publishes_gripper_state(lifecycle_interface):
             1,
         )
 
-    for _ in range(10):
-        rclpy.spin_once(driver.node)
-        time.sleep(0.1)
+    timeout = time.time() + 1.0
+    while time.time() < timeout and len(messages) == 0:
+        rclpy.spin_once(driver.node, timeout_sec=0.1)
 
     driver.change_state(Transition.TRANSITION_DEACTIVATE)
     driver.change_state(Transition.TRANSITION_CLEANUP)

--- a/schunk_gripper_dummy/schunk_gripper_dummy/dummy.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/dummy.py
@@ -151,7 +151,7 @@ class Dummy(object):
             self.set_actual_speed(actual_speed)
             time.sleep(0.01)
 
-    def post(self, msg: dict) -> dict:
+    def update(self, msg: dict) -> dict:
         self.data[msg["inst"]] = [msg["value"]]
         if msg["inst"] == self.plc_output:
             self.plc_output_buffer = bytearray(bytes.fromhex(msg["value"]))

--- a/schunk_gripper_dummy/schunk_gripper_dummy/dummy.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/dummy.py
@@ -1,4 +1,4 @@
-from threading import Thread
+from threading import Thread, Timer
 import time
 from importlib.resources import files
 import json
@@ -75,6 +75,7 @@ class Dummy(object):
             raise ValueError("Unknown parameter set")
 
         self.starttime = time.time()
+        self.reachable = True
         self.thread = Thread(target=self._run)
         self.running = False
         self.done = False
@@ -128,6 +129,16 @@ class Dummy(object):
             self.set_system_uptime(int(elapsed))
             time.sleep(1)
         print("Done")
+
+    def handle_events(self, events: dict) -> bool:
+        if "lose_connection_sec" in events:
+            self.reachable = False
+
+            def reset() -> None:
+                self.reachable = True
+
+            Timer(interval=events["lose_connection_sec"], function=reset).start()
+        return True
 
     def acknowledge(self) -> None:
         self.set_status_bit(bit=0, value=True)

--- a/schunk_gripper_dummy/schunk_gripper_dummy/main.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/main.py
@@ -35,13 +35,10 @@ def create_webserver(dummy: Dummy):
         background_tasks.add_task(dummy.update, msg)
         return {"result": 0}
 
-    @webserver.get("/adi/{path}")
+    @webserver.get("/adi/data.json")
     async def get(request: Request):
-        path = request.path_params["path"]
         params = dict(request.query_params)
-        if path == "data.json":
-            return dummy.get_data(params)
-        return None
+        return dummy.get_data(params)
 
     return webserver
 

--- a/schunk_gripper_dummy/schunk_gripper_dummy/main.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/main.py
@@ -20,7 +20,7 @@ def create_webserver(dummy: Dummy):
     )
 
     @webserver.post("/adi/update.json")
-    async def post(
+    async def update(
         inst: str = Form(...),
         value: str = Form(...),
         elem: Optional[int] = Form(None),
@@ -32,7 +32,7 @@ def create_webserver(dummy: Dummy):
             return {"result": 1}
         if not all(digit in string.hexdigits for digit in str(msg["value"])):
             return {"result": 1}
-        background_tasks.add_task(dummy.post, msg)
+        background_tasks.add_task(dummy.update, msg)
         return {"result": 0}
 
     @webserver.get("/adi/{path}")

--- a/schunk_gripper_dummy/schunk_gripper_dummy/tests/test_dummy.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/tests/test_dummy.py
@@ -376,3 +376,21 @@ def test_dummy_supports_grip_at_position():
     assert dummy.get_status_bit(bit=12) == 1  # workpiece gripped
     assert dummy.get_status_bit(bit=4) == 1  # command successfully processed
     assert dummy.get_status_bit(bit=31) == 1  # GPE activated
+
+
+def test_dummy_handles_events():
+    dummy = Dummy()
+    assert dummy.reachable
+
+    events = {}
+    assert dummy.handle_events(events)
+
+    # Connection loss
+    duration = 0.2
+    buffer = 0.5
+    events = {"lose_connection_sec": duration}
+    for _ in range(3):
+        assert dummy.handle_events(events)
+        assert not dummy.reachable
+        time.sleep(duration + buffer)
+        assert dummy.reachable

--- a/schunk_gripper_dummy/schunk_gripper_dummy/tests/test_dummy.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/tests/test_dummy.py
@@ -195,7 +195,7 @@ def test_dummy_moves_to_absolute_position():
             "value": control_double_word + set_position + set_speed + gripping_force,
         }
 
-        dummy.post(command)
+        dummy.update(command)
         assert dummy.get_actual_position() == pytest.approx(target_pos, rel=1e-3)
         assert dummy.get_status_bit(bit=13) == 1  # position reached
         assert dummy.get_status_bit(bit=4) == 1  # command successfully processed
@@ -217,7 +217,7 @@ def test_dummy_rejects_invalid_speeds_for_move_absolute_commands():
             "value": control_double_word + set_position + set_speed + gripping_force,
         }
 
-        dummy.post(command)
+        dummy.update(command)
 
         # Dummy shouldn't move
         assert dummy.get_actual_position() == pytest.approx(expected_position, rel=1e-3)
@@ -240,7 +240,7 @@ def test_dummy_moves_to_relative_position():
         "value": control_double_word + set_position + set_speed + gripping_force,
     }
     before = dummy.get_actual_position()
-    dummy.post(command)
+    dummy.update(command)
     after = dummy.get_actual_position()
     assert after < before  # we are decreasing
     assert after == pytest.approx(before + target_pos, rel=1e-3)

--- a/schunk_gripper_dummy/schunk_gripper_dummy/tests/test_requests.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/tests/test_requests.py
@@ -33,24 +33,24 @@ def test_dummy_survives_invalid_data_requests():
     assert dummy.get_data(query) == expected
 
 
-def test_dummy_stores_post_requests():
+def test_dummy_stores_update_requests():
     dummy = Dummy()
 
     # Using the plc command variable
     msg = "00112233445566778899AABBCCDDEEFF"
     data = {"inst": dummy.plc_output, "value": msg}
-    dummy.post(data)
+    dummy.update(data)
     assert dummy.data[dummy.plc_output] == [msg]
 
     # Using general variables
     msg = "AABBCCDD"
     inst = "0x0238"
     data = {"inst": inst, "value": msg}
-    dummy.post(data)
+    dummy.update(data)
     assert dummy.data[inst] == [msg]
 
 
-def test_dummy_rejects_invalid_post_requests():
+def test_dummy_rejects_invalid_update_requests():
     dummy = Dummy()
     dummy.start()
     server = create_webserver(dummy)
@@ -74,14 +74,14 @@ def test_dummy_rejects_invalid_post_requests():
     dummy.stop()
 
 
-def test_dummy_resets_success_status_bits_with_new_post_requests():
+def test_dummy_resets_success_status_bits_with_new_update_requests():
     dummy = Dummy()
     dummy.set_status_bit(bit=13, value=True)  # position reached
     dummy.set_status_bit(bit=4, value=True)  # command successful
     dummy.set_status_bit(bit=12, value=True)  # workpiece gripped
     empty_command = "01" + "".zfill(30)  # only fast stop active
     data = {"inst": dummy.plc_output, "value": empty_command}
-    dummy.post(data)
+    dummy.update(data)
     assert dummy.get_status_bit(bit=13) == 0
     assert dummy.get_status_bit(bit=4) == 0
     assert dummy.get_status_bit(bit=12) == 0

--- a/schunk_gripper_dummy/schunk_gripper_dummy/tests/test_webserver.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/tests/test_webserver.py
@@ -26,3 +26,16 @@ def test_update_route_is_available():
     assert response.is_success
 
     dummy.stop()
+
+
+def test_events_route_is_available():
+    dummy = Dummy()
+    dummy.start()
+    server = create_webserver(dummy)
+    client = TestClient(server)
+
+    events = {}
+    response = client.post("/adi/events.json", json=events)
+    assert response.is_success
+
+    dummy.stop()

--- a/schunk_gripper_interfaces/CMakeLists.txt
+++ b/schunk_gripper_interfaces/CMakeLists.txt
@@ -19,6 +19,7 @@ rosidl_generate_interfaces(
     srv/Release.srv
     srv/ShowConfiguration.srv
     srv/ShowGripperSpecification.srv
+    msg/ConnectionState.msg
     msg/Gripper.msg
     msg/GripperState.msg
     msg/GripperSpec.msg

--- a/schunk_gripper_interfaces/msg/ConnectionState.msg
+++ b/schunk_gripper_interfaces/msg/ConnectionState.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+string[] grippers   # List of grippers with unique IDs
+bool[] connected    # List of corresponding connection states (connected = True, disconnected = False)

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -170,6 +170,7 @@ class Driver(object):
                     baudrate=115200,
                     parity="E" if supports_parity(serial_port) else "N",
                     stopbits=1,
+                    timeout=0.01,
                     trace_connect=None,
                     trace_packet=None,
                     trace_pdu=None,

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -170,7 +170,7 @@ class Driver(object):
                     baudrate=115200,
                     parity="E" if supports_parity(serial_port) else "N",
                     stopbits=1,
-                    timeout=0.01,
+                    timeout=0.05,
                     trace_connect=None,
                     trace_packet=None,
                     trace_pdu=None,

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -490,8 +490,10 @@ class Driver(object):
             data = self.read_module_parameter(self.plc_input)
             if data:
                 self.plc_input_buffer = data
-                return True
-        return False
+                self.connected = True
+            else:
+                self.connected = False
+            return self.connected
 
     def send_plc_output(self) -> bool:
         with self.output_buffer_lock:

--- a/schunk_gripper_library/schunk_gripper_library/tests/conftest.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from .etc.pseudo_terminals import Connection
 from unittest.mock import patch
 import httpx
+import pymodbus
 
 
 @pytest.fixture(scope="module")
@@ -27,6 +28,26 @@ def simulate_httpx_failure():
         return pass_through(self, *args, **kwargs)
 
     patcher = patch("httpx.Client.get", new=side_effect)
+    patcher.start()
+
+    yield controller
+
+    patcher.stop()
+
+
+@pytest.fixture
+def simulate_pymodbus_failure():
+    controller = {"exception": None}
+    pass_through = pymodbus.client.ModbusSerialClient.read_holding_registers
+
+    def side_effect(self, *args, **kwargs):
+        if controller["exception"] is not None:
+            raise controller["exception"]
+        return pass_through(self, *args, **kwargs)
+
+    patcher = patch(
+        "pymodbus.client.ModbusSerialClient.read_holding_registers", new=side_effect
+    )
     patcher.start()
 
     yield controller

--- a/schunk_gripper_library/schunk_gripper_library/tests/conftest.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 from .etc.pseudo_terminals import Connection
+from unittest.mock import patch
+import httpx
 
 
 @pytest.fixture(scope="module")
@@ -12,3 +14,21 @@ def pseudo_terminals():
 
     print("Closing both pseudo terminals")
     connection.close()
+
+
+@pytest.fixture
+def simulate_httpx_failure():
+    controller = {"exception": None}
+    pass_through = httpx.Client.get
+
+    def side_effect(self, *args, **kwargs):
+        if controller["exception"] is not None:
+            raise controller["exception"]
+        return pass_through(self, *args, **kwargs)
+
+    patcher = patch("httpx.Client.get", new=side_effect)
+    patcher.start()
+
+    yield controller
+
+    patcher.stop()

--- a/schunk_gripper_library/schunk_gripper_library/tests/etc/events.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/etc/events.py
@@ -1,8 +1,10 @@
 import httpx
 from httpx import ConnectError, ConnectTimeout
+import subprocess
+from threading import Timer
 
 
-def lose_connection(
+def lose_tcp_connection(
     host: str = "0.0.0.0", port: int = 8000, duration_sec: float = 1.0
 ) -> bool:
     events = {"lose_connection_sec": duration_sec}
@@ -11,3 +13,24 @@ def lose_connection(
     except (ConnectError, ConnectTimeout):
         return False
     return response.is_success
+
+
+def lose_modbus_connection(duration_sec: float = 1.0) -> bool:
+    try:
+        result = subprocess.run(
+            ["pgrep", "-fa", "BKS_Sim"], capture_output=True, text=True, check=True
+        )
+        line = result.stdout.strip()
+        pid = int(line.split()[0])
+
+        subprocess.run(["kill", "-19", str(pid)], check=True)  # stop
+
+        def reset() -> None:
+            subprocess.run(["kill", "-18", str(pid)], check=True)  # continue
+
+        Timer(interval=duration_sec, function=reset).start()
+
+    except subprocess.CalledProcessError:
+        return False
+
+    return True

--- a/schunk_gripper_library/schunk_gripper_library/tests/etc/events.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/etc/events.py
@@ -1,0 +1,13 @@
+import httpx
+from httpx import ConnectError, ConnectTimeout
+
+
+def lose_connection(
+    host: str = "0.0.0.0", port: int = 8000, duration_sec: float = 1.0
+) -> bool:
+    events = {"lose_connection_sec": duration_sec}
+    try:
+        response = httpx.post(f"http://{host}:{port}/adi/events.json", json=events)
+    except (ConnectError, ConnectTimeout):
+        return False
+    return response.is_success

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
@@ -1,6 +1,6 @@
 from schunk_gripper_library.driver import Driver
 from schunk_gripper_library.utility import skip_without_gripper
-from .etc.events import lose_connection
+from .etc.events import lose_tcp_connection, lose_modbus_connection
 import time
 import httpx
 import pymodbus
@@ -13,14 +13,34 @@ def test_driver_has_reconnection_interval():
 
 
 @skip_without_gripper
-def test_driver_automatically_reestablishes_connection():
+def test_driver_automatically_reestablishes_tcp_connection():
     driver = Driver()
     assert driver.connect(host="0.0.0.0", port=8000)
 
     # Cut the connection to the gripper
     # and check that the driver reestablishes it automatically.
     downtime = 1.23
-    assert lose_connection(duration_sec=downtime)
+    assert lose_tcp_connection(duration_sec=downtime)
+    time.sleep(0.1)
+    assert not driver.connected
+
+    time.sleep(downtime + driver.reconnect_interval)
+    assert driver.connected
+
+    driver.disconnect()
+
+
+@skip_without_gripper
+def test_driver_automatically_reestablishes_modbus_connection():
+    driver = Driver()
+    assert driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
+
+    downtime = 0.5
+    assert lose_modbus_connection(duration_sec=downtime)
+
+    # Modbus has several seconds default timeouts,
+    # but we need to react fast to inform high-level callers about
+    # the connection status
     time.sleep(0.1)
     assert not driver.connected
 

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
@@ -2,6 +2,7 @@ from schunk_gripper_library.driver import Driver
 from schunk_gripper_library.utility import skip_without_gripper
 from .etc.events import lose_connection
 import time
+import httpx
 
 
 def test_driver_has_reconnection_interval():
@@ -24,5 +25,21 @@ def test_driver_automatically_reestablishes_connection():
 
     time.sleep(downtime + driver.reconnect_interval)
     assert driver.connected
+
+    driver.disconnect()
+
+
+@skip_without_gripper
+def test_driver_handles_httpx_exceptions_during_polling(simulate_httpx_failure):
+
+    driver = Driver()
+    assert driver.connect(host="0.0.0.0", port=8000)
+
+    # Interrupt the driver's polling thread
+    time.sleep(1)
+    simulate_httpx_failure["exception"] = httpx.ReadTimeout("Simulated read timeout")
+
+    time.sleep(0.1)
+    assert driver.polling_thread.is_alive()
 
     driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
@@ -41,7 +41,7 @@ def test_driver_automatically_reestablishes_modbus_connection():
     # Modbus has several seconds default timeouts,
     # but we need to react fast to inform high-level callers about
     # the connection status
-    time.sleep(0.1)
+    time.sleep(0.5)
     assert not driver.connected
 
     time.sleep(downtime + driver.reconnect_interval)

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
@@ -1,0 +1,28 @@
+from schunk_gripper_library.driver import Driver
+from schunk_gripper_library.utility import skip_without_gripper
+from .etc.events import lose_connection
+import time
+
+
+def test_driver_has_reconnection_interval():
+    driver = Driver()
+    assert isinstance(driver.reconnect_interval, float)
+    assert driver.reconnect_interval > 0
+
+
+@skip_without_gripper
+def test_driver_automatically_reestablishes_connection():
+    driver = Driver()
+    assert driver.connect(host="0.0.0.0", port=8000)
+
+    # Cut the connection to the gripper
+    # and check that the driver reestablishes it automatically.
+    downtime = 1.23
+    assert lose_connection(duration_sec=downtime)
+    time.sleep(0.1)
+    assert not driver.connected
+
+    time.sleep(downtime + driver.reconnect_interval)
+    assert driver.connected
+
+    driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
@@ -30,8 +30,25 @@ def test_driver_automatically_reestablishes_connection():
 
 
 @skip_without_gripper
-def test_driver_handles_httpx_exceptions_during_polling(simulate_httpx_failure):
+def test_driver_handles_httpx_exceptions_on_startup(simulate_httpx_failure):
 
+    # Check httpx.ConnectError
+    simulate_httpx_failure["exception"] = httpx.ConnectError("Simulated connect error")
+    driver = Driver()
+    assert not driver.connect(host="0.0.0.0", port=8000)
+    driver.disconnect()
+
+    # Check httpx.ConnectTimeout
+    simulate_httpx_failure["exception"] = httpx.ConnectTimeout(
+        "Simulated connect timeout"
+    )
+    driver = Driver()
+    assert not driver.connect(host="0.0.0.0", port=8000)
+    driver.disconnect()
+
+
+@skip_without_gripper
+def test_driver_handles_httpx_exceptions_during_polling(simulate_httpx_failure):
     driver = Driver()
     assert driver.connect(host="0.0.0.0", port=8000)
 

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
@@ -3,6 +3,7 @@ from schunk_gripper_library.utility import skip_without_gripper
 from .etc.events import lose_connection
 import time
 import httpx
+import pymodbus
 
 
 def test_driver_has_reconnection_interval():
@@ -84,4 +85,16 @@ def test_driver_handles_httpx_exceptions_during_polling(simulate_httpx_failure):
     time.sleep(driver.reconnect_interval)
     assert driver.connected
 
+    driver.disconnect()
+
+
+@skip_without_gripper
+def test_driver_handles_pymodbus_exceptions_on_startup(simulate_pymodbus_failure):
+
+    # Check pymodbus.exceptions.ModbusIOException
+    simulate_pymodbus_failure["exception"] = pymodbus.exceptions.ModbusIOException(
+        "Simulated IO error"
+    )
+    driver = Driver()
+    assert not driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
     driver.disconnect()


### PR DESCRIPTION
## Background
Grippers can lose their connection in the field, for instance due to cable breakage, power shortages, etc.
We need a clean method to automatically re-establish the connection to the loaded devices.

**Note**: This feature should be optional for industrial usage

## High-level goals
The setup should
- automatically detect (partial) communication loss and react accordingly (per gripper)
- automatically re-connect with a _best effort_ strategy
- Publish the connection status to a respective topic (always)

## Steps
- [x] Update the web dummy to support interrupting the connection
- [x] Add a `pytest` mechanism for checking the handling of `httpx`  and `pymodbus` exceptions with the library
- [x] Implement the reconnect mechanism in the library
- [x] Adjust the ROS2 driver if needed
- [x] Publish an adequate topic with the `connected` state of all modules
- [x] Check this with Modbus grippers (dual-setup)
- [x] Check this with TCP/IP grippers