### PR TITLE
Hide configuration-specific services after `on_configure`

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -338,6 +338,8 @@ class Driver(Node):
         self.destroy_service(self.add_gripper_srv)
         self.destroy_service(self.reset_grippers_srv)
         self.destroy_service(self.show_configuration_srv)
+        self.destroy_service(self.save_configuration_srv)
+        self.destroy_service(self.load_previous_configuration_srv)
 
         return TransitionCallbackReturn.SUCCESS
 


### PR DESCRIPTION
## Steps
- [x] Fix the check for service availability in `conftest.py`
- [x] Adapt `load_previous_configuration` and `save_configuration` accordingly