### PR TITLE
Adapt the driver's `needs_synchronize` check

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -281,7 +281,11 @@ class Driver(Node):
         return True
 
     def needs_synchronize(self, gripper: Gripper) -> bool:
-        serial_ports = [gripper["serial_port"] for gripper in self.grippers]
+        serial_ports = [
+            gripper["serial_port"]
+            for gripper in self.grippers
+            if gripper["serial_port"]
+        ]
         if serial_ports.count(gripper["serial_port"]) > 1:
             return True
         return False

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -191,6 +191,56 @@ def test_driver_checks_if_grippers_need_synchronization(ros2: None):
         assert not driver.needs_synchronize(gripper)
 
 
+def test_driver_doesnt_synchronize_empty_serial_ports(ros2):
+    driver = Driver("driver")
+    assert driver.reset_grippers()
+    assert driver.add_gripper(host="192.168.0.2", port=8000)
+
+    other = Gripper(
+        {
+            "host": "192.168.0.3",
+            "port": 8000,
+            "serial_port": "",
+            "device_id": 0,
+            "driver": GripperDriver(),
+            "gripper_id": "",
+        }
+    )
+    driver.grippers.append(other)
+    assert not driver.needs_synchronize(other)
+
+
+def test_driver_synchronizes_ethernet_grippers_with_nonempty_serial_ports(ros2):
+    driver = Driver("driver")
+    assert driver.reset_grippers()
+
+    one = Gripper(
+        {
+            "host": "192.168.0.2",
+            "port": 8000,
+            "serial_port": "this will allow to run Ethernet grippers with a scheduler",
+            "device_id": 0,
+            "driver": GripperDriver(),
+            "gripper_id": "",
+        }
+    )
+    driver.grippers.append(one)
+    two = Gripper(
+        {
+            "host": "192.168.0.3",
+            "port": 8000,
+            "serial_port": "this will allow to run Ethernet grippers with a scheduler",
+            "device_id": 0,
+            "driver": GripperDriver(),
+            "gripper_id": "",
+        }
+    )
+    driver.grippers.append(two)
+
+    assert driver.needs_synchronize(one)
+    assert driver.needs_synchronize(two)
+
+
 @skip_without_gripper
 def test_driver_offers_callbacks_for_acknowledge_and_fast_stop(ros2: None):
     driver = Driver("driver")


### PR DESCRIPTION
## Steps
- [x] Confirm that empty `serial_port` strings activate the scheduler
- [x] Exclude empty strings from this check
- [x] Add regression tests

## Resolution
For testing the scheduler, we still activate synchronization of Ethernet grippers through setting a non-empty `serial_port`.