### PR TITLE
Add headless mode

### DIFF
--- a/schunk_gripper_driver/launch/driver.launch.py
+++ b/schunk_gripper_driver/launch/driver.launch.py
@@ -46,7 +46,16 @@ start_empty = DeclareLaunchArgument(
     description="Whether to drop gripper-specific launch arguments",
 )
 
-args = [host, port, serial_port, device_id, start_empty]
+headless = DeclareLaunchArgument(
+    "headless",
+    default_value="false",
+    description=(
+        "Whether to `configure` and `activate` the driver "
+        "using the last successful configuration",
+    ),
+)
+
+args = [host, port, serial_port, device_id, start_empty, headless]
 
 
 def generate_launch_description():
@@ -64,6 +73,7 @@ def generate_launch_description():
                     {"serial_port": LaunchConfiguration("serial_port")},
                     {"device_id": LaunchConfiguration("device_id")},
                     {"start_empty": LaunchConfiguration("start_empty")},
+                    {"headless": LaunchConfiguration("headless")},
                 ],
                 respawn=True,
                 output="both",

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -75,6 +75,7 @@ class Driver(Node):
             "serial_port": "/dev/ttyUSB0",
             "device_id": 12,
             "start_empty": False,
+            "headless": False,
         }
         for name, default_value in self.init_parameters.items():
             self.declare_parameter(name, default_value)

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_parameters.py
@@ -36,9 +36,8 @@ def test_whether_we_cover_all_driver_parameters(driver):
     # Meta-check if we test all our node parameters
     future = list_params_client.call_async(ListParameters.Request())
     rclpy.spin_until_future_complete(node, future)
-    assert (
-        len(DRIVER_PARAMETERS) == len(future.result().result.names) - 1
-    )  # There's a default node parameter: `use_sim_time``
+    for param in DRIVER_PARAMETERS:
+        assert param in future.result().result.names
 
 
 @skip_without_gripper


### PR DESCRIPTION
## Background
When using this driver in industrial settings, users will perform the "setup" once and later expect this driver to run with this "setup" every time the plant powers up in the morning.
We need a mechanism to
- load the previous configuration (if successful)
- automatically transition through the `inactive` and `active` states
- fail gracefully when something's not right with the configuration

## Steps
- [x] Add a suitable launch file parameter
- [ ] Find the right way to trigger state transitions from this driver
- [ ] ...