### PR TITLE
Robustify reading the command received bit

### DIFF
--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -234,9 +234,9 @@ class Driver(object):
             return False
 
         def do() -> bool:
+            cmd_toggle_before = self.get_status_bit(bit=5)
             self.clear_plc_output()
             self.send_plc_output()
-            cmd_toggle_before = self.get_status_bit(bit=5)
             self.set_control_bit(bit=2, value=True)
             self.send_plc_output()
             desired_bits = {"0": 1, "5": cmd_toggle_before ^ 1}
@@ -252,9 +252,9 @@ class Driver(object):
             return False
 
         def do() -> bool:
+            cmd_toggle_before = self.get_status_bit(bit=5)
             self.clear_plc_output()
             self.send_plc_output()
-            cmd_toggle_before = self.get_status_bit(bit=5)
             self.set_control_bit(
                 bit=0, value=False
             )  # activate fast stop (inverted behavior)
@@ -271,10 +271,9 @@ class Driver(object):
         if not self.connected:
             return False
 
+        cmd_toggle_before = self.get_status_bit(bit=5)
         self.clear_plc_output()
         self.send_plc_output()
-
-        cmd_toggle_before = self.get_status_bit(bit=5)
         self.set_control_bit(bit=1, value=True)
         self.send_plc_output()
 
@@ -296,9 +295,9 @@ class Driver(object):
             return False
 
         def start():
+            cmd_toggle_before = self.get_status_bit(bit=5)
             self.clear_plc_output()
             self.send_plc_output()
-            cmd_toggle_before = self.get_status_bit(bit=5)
             self.set_control_bit(bit=13, value=True)
             if self.gpe_available():
                 self.set_control_bit(bit=31, value=use_gpe)
@@ -334,10 +333,9 @@ class Driver(object):
         if not self.connected:
             return False
 
+        cmd_toggle_before = self.get_status_bit(bit=5)
         self.clear_plc_output()
         self.send_plc_output()
-
-        cmd_toggle_before = self.get_status_bit(bit=5)
         self.set_control_bit(bit=14, value=True)
         self.set_control_bit(bit=31, value=use_gpe)
         self.set_target_position(position)
@@ -361,10 +359,9 @@ class Driver(object):
             return False
 
         def start() -> bool:
+            cmd_toggle_before = self.get_status_bit(bit=5)
             self.clear_plc_output()
             self.send_plc_output()
-
-            cmd_toggle_before = self.get_status_bit(bit=5)
             self.set_control_bit(bit=12, value=True)
             self.set_control_bit(bit=7, value=outward)
             if self.gpe_available():
@@ -402,9 +399,9 @@ class Driver(object):
             return False
 
         def start() -> bool:
+            cmd_toggle_before = self.get_status_bit(bit=5)
             self.clear_plc_output()
             self.send_plc_output()
-            cmd_toggle_before = self.get_status_bit(bit=5)
             self.set_control_bit(bit=11, value=True)
             if self.gpe_available():
                 self.set_control_bit(bit=31, value=use_gpe)

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -3,6 +3,7 @@ from schunk_gripper_library.utility import skip_without_gripper
 import pytest
 import struct
 from threading import Timer
+import time
 
 
 @skip_without_gripper
@@ -658,3 +659,20 @@ def test_driver_offers_method_for_composing_gripper_type():
     for entry in valid_combinations:
         gripper_type = driver.compose_gripper_type(**entry["args"])
         assert gripper_type == entry["expected"]
+
+
+@skip_without_gripper
+def test_clearing_plc_output_does_not_toggle_the_command_received_bit():
+    driver = Driver()
+    assert driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
+
+    for _ in range(10):
+        cmd_toggle_before = driver.get_status_bit(bit=5)
+        driver.clear_plc_output()
+        driver.send_plc_output()
+        time.sleep(0.1)
+        driver.receive_plc_input()
+        cmd_toggle_after = driver.get_status_bit(bit=5)
+        assert cmd_toggle_after == cmd_toggle_before
+
+    driver.disconnect()


### PR DESCRIPTION
## Background
The command received bit does not toggle when the plc output is cleared.
This means we can do that as the first step in each high-level method
and avoid possible race conditions when later waiting for the desired
bit set.

This race condition showed itself for very short methods, such as `stop_jogging`.

## Steps
- [x] Add a regression test that documents this behavior
- [x] Adjust all top-level methods in the library