### PR TITLE
Improve the test setup for getting dynamic service types

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/conftest.py
@@ -29,6 +29,8 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from rclpy.node import Node
 import os
 from rcl_interfaces.msg import Parameter, ParameterValue, ParameterType
+from typing_extensions import Any
+import importlib
 
 
 def get_directory_size(directory):
@@ -155,6 +157,15 @@ class LifecycleInterface(object):
         rclpy.spin_until_future_complete(self.node, future)
         grippers = future.result().grippers
         return grippers
+
+    def get_service_type(self, srv_name: str) -> Any | None:
+        services = self.node.get_service_names_and_types()
+        for name, types in services:
+            if name == srv_name:
+                pkg, _, srv = types[0].split("/")
+                module = importlib.import_module(f"{pkg}.srv")
+                return getattr(module, srv)
+        return None
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Background
We need a mechanism to test services with two (or more) distinct types.

This adds the `get_service_type` method to the `LifecycleInterface` instance that we use in most ROS2 system tests.

## Usage

```python
def test_some_feature(lifecycle_interface):
    driver = lifecycle_interface
    node = Node("test_some_feature")
    
    # ...

    ServiceType= driver.get_service_type(
            "/some/global/service/name"
        )
    client = node.create_client(
        ServiceType,
        "/some/global/service/name",
    )
    request = ServiceType.Request()

    # ....

    future = client.call_async(request)
    rclpy.spin_until_future_complete(node, future)

    # ...    

```
