### PR TITLE
Support the `GripAtPosition` feature

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -26,6 +26,8 @@ from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
     MoveToAbsolutePosition,
     Grip,
     GripGPE,
+    GripAtPosition,
+    GripAtPositionGPE,
     Release,
     StartJogging,
     StartJoggingGPE,
@@ -424,10 +426,10 @@ class Driver(Node):
                 )
             )
             if gripper["driver"].gpe_available():
-                service_types = [GripGPE]
+                service_types = [GripGPE, GripAtPositionGPE]
             else:
-                service_types = [Grip]
-            service_names = ["grip"]
+                service_types = [Grip, GripAtPosition]
+            service_names = ["grip", "grip_at_position"]
             for srv_name, srv_type in zip(service_names, service_types):
                 self.gripper_services.append(
                     self.create_service(
@@ -855,7 +857,9 @@ class Driver(Node):
         self.get_logger().debug("---> Grip")
         use_gpe = getattr(request, "use_gpe", False)
         scheduler = self.scheduler if self.needs_synchronize(gripper) else None
+        at_position = getattr(request, "at_position", None)
         response.success = gripper["driver"].grip(
+            position=at_position,
             force=request.force,
             use_gpe=use_gpe,
             outward=request.outward,

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -858,6 +858,9 @@ class Driver(Node):
         use_gpe = getattr(request, "use_gpe", False)
         scheduler = self.scheduler if self.needs_synchronize(gripper) else None
         at_position = getattr(request, "at_position", None)
+        if at_position is not None:
+            at_position = int(at_position * 1e6)
+
         response.success = gripper["driver"].grip(
             position=at_position,
             force=request.force,

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_gpe_variants.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_gpe_variants.py
@@ -19,6 +19,8 @@ from schunk_gripper_library.utility import skip_without_gripper
 from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
     Grip,
     GripGPE,
+    GripAtPosition,
+    GripAtPositionGPE,
 )
 
 
@@ -40,7 +42,19 @@ def test_grip_callback_handles_all_gpe_variants(ros2):
             request=GripGPE.Request(), response=GripGPE.Response(), gripper=gripper
         )
 
-        # More grip versions here ..
+        # GripAtPositon
+        driver._grip_cb(
+            request=GripAtPosition.Request(),
+            response=GripAtPosition.Response(),
+            gripper=gripper,
+        )
+
+        # GripAtPositionGPE
+        driver._grip_cb(
+            request=GripAtPositionGPE.Request(),
+            response=GripAtPositionGPE.Response(),
+            gripper=gripper,
+        )
 
     driver.on_deactivate(state=None)
     driver.on_cleanup(state=None)
@@ -55,15 +69,20 @@ def test_driver_offers_gpe_specific_grip_services(ros2):
     # if the driver creates the expected services
 
     modules = ["EGU_50_M_B", "EGK_25_N_B"]
-    expected_types = [GripGPE, Grip]
+    expected_grip_types = [GripGPE, Grip]
+    expected_grip_at_position_types = [GripAtPositionGPE, GripAtPosition]
 
-    for module, srv_type in zip(modules, expected_types):
+    for module, grip_type, grip_at_position_type in zip(
+        modules, expected_grip_types, expected_grip_at_position_types
+    ):
         driver.grippers[0]["driver"].module = module
         driver.on_activate(state=None)
 
         for service in driver.gripper_services:
             if service.srv_name.endswith("/grip"):
-                assert service.srv_type == srv_type
+                assert service.srv_type == grip_type
+            if service.srv_name.endswith("/grip_at_position"):
+                assert service.srv_type == grip_at_position_type
 
         driver.on_deactivate(state=None)
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -350,10 +350,10 @@ def test_driver_implements_grip_at_position_and_release(lifecycle_interface):
         ), f"{gripper}: release service unavailable"
 
         targets = [
-            {"force": 50, "position": 10000, "use_gpe": False, "outward": False},
-            {"force": 100, "position": 20000, "use_gpe": True, "outward": False},
-            {"force": 75, "position": 15000, "use_gpe": False, "outward": True},
-            {"force": 88, "position": 12000, "use_gpe": True, "outward": True},
+            {"force": 50, "position": 0.01, "use_gpe": False, "outward": False},
+            {"force": 100, "position": 0.02, "use_gpe": True, "outward": False},
+            {"force": 75, "position": 0.015, "use_gpe": False, "outward": True},
+            {"force": 88, "position": 0.012, "use_gpe": True, "outward": True},
         ]
 
         for target in targets:

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -381,6 +381,44 @@ def test_driver_implements_grip_at_position_and_release(lifecycle_interface):
 
 
 @skip_without_gripper
+def test_driver_implements_grip_at_position_with_or_without_gpe(lifecycle_interface):
+    driver = lifecycle_interface
+    driver.change_state(Transition.TRANSITION_CONFIGURE)
+    driver.change_state(Transition.TRANSITION_ACTIVATE)
+
+    node = Node("grip_at_position_service_with_or_without_gpe")
+
+    for gripper in driver.list_grippers():
+        service_name = f"/schunk/driver/{gripper}/grip_at_position"
+
+        ServiceType = driver.get_service_type(service_name)
+        assert ServiceType is not None, f"{gripper}: service type not found"
+
+        client = node.create_client(ServiceType, service_name)
+        assert client.wait_for_service(timeout_sec=5), f"{gripper}: service unavailable"
+
+        req = ServiceType.Request()
+        req.force = 100
+        req.outward = False
+        req.at_position = 50
+
+        # If the service supports use_gpe, set it
+        if hasattr(req, "use_gpe"):
+            req.use_gpe = False
+        else:
+            assert not hasattr(req, "use_gpe"), f"{gripper}: unexpected use_gpe field"
+
+        future = client.call_async(req)
+        rclpy.spin_until_future_complete(node, future, timeout_sec=5)
+        assert future.result() is not None, f"{gripper}: no response from service"
+
+    driver.change_state(Transition.TRANSITION_DEACTIVATE)
+    driver.change_state(Transition.TRANSITION_CLEANUP)
+
+    node.destroy_node()
+
+
+@skip_without_gripper
 def test_driver_implements_show_specification(lifecycle_interface):
     driver = lifecycle_interface
     driver.change_state(Transition.TRANSITION_CONFIGURE)

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -305,6 +305,82 @@ def test_driver_implements_grip_and_release(lifecycle_interface):
 
 
 @skip_without_gripper
+def test_driver_implements_grip_at_position_and_release(lifecycle_interface):
+    driver = lifecycle_interface
+
+    node = Node("check_grip_at_position")
+    add_client = node.create_client(AddGripper, "/schunk/driver/add_gripper")
+    reset_client = node.create_client(Trigger, "/schunk/driver/reset_grippers")
+    assert add_client.wait_for_service(timeout_sec=2)
+    assert reset_client.wait_for_service(timeout_sec=2)
+
+    # Reset grippers (drop default modbus gripper)
+    reset_req = Trigger.Request()
+    future = reset_client.call_async(reset_req)
+    rclpy.spin_until_future_complete(node, future)
+    assert future.result().success
+
+    add_req = AddGripper.Request()
+    add_req.gripper.host = "0.0.0.0"
+    add_req.gripper.port = 8000
+    future = add_client.call_async(add_req)
+    rclpy.spin_until_future_complete(node, future)
+    assert future.result().success
+
+    driver.change_state(Transition.TRANSITION_CONFIGURE)
+    driver.change_state(Transition.TRANSITION_ACTIVATE)
+
+    for gripper in driver.list_grippers():
+        grip_service_name = f"/schunk/driver/{gripper}/grip_at_position"
+        GripServiceType = driver.get_service_type(grip_service_name)
+        assert (
+            GripServiceType is not None
+        ), f"{gripper}: grip_at_position service not found"
+        grip_client = node.create_client(GripServiceType, grip_service_name)
+        assert grip_client.wait_for_service(
+            timeout_sec=5
+        ), f"{gripper}: grip_at_position service unavailable"
+
+        release_service_name = f"/schunk/driver/{gripper}/release"
+        ReleaseServiceType = driver.get_service_type(release_service_name)
+        assert ReleaseServiceType is not None, f"{gripper}: release service not found"
+        release_client = node.create_client(ReleaseServiceType, release_service_name)
+        assert release_client.wait_for_service(
+            timeout_sec=5
+        ), f"{gripper}: release service unavailable"
+
+        targets = [
+            {"force": 50, "position": 10000, "use_gpe": False, "outward": False},
+            {"force": 100, "position": 20000, "use_gpe": True, "outward": False},
+            {"force": 75, "position": 15000, "use_gpe": False, "outward": True},
+            {"force": 88, "position": 12000, "use_gpe": True, "outward": True},
+        ]
+
+        for target in targets:
+            # Grip at position
+            grip_req = GripServiceType.Request()
+            grip_req.force = target["force"]
+            grip_req.at_position = target["position"]
+            grip_req.outward = target["outward"]
+            if hasattr(grip_req, "use_gpe"):
+                grip_req.use_gpe = target["use_gpe"]
+
+            future = grip_client.call_async(grip_req)
+            rclpy.spin_until_future_complete(node, future)
+            assert future.result().success, f"{gripper}: {future.result().message}"
+
+            # Release
+            release_req = ReleaseServiceType.Request()
+            future = release_client.call_async(release_req)
+            rclpy.spin_until_future_complete(node, future)
+            assert future.result().success, f"{gripper}: {future.result().message}"
+
+    driver.change_state(Transition.TRANSITION_DEACTIVATE)
+    driver.change_state(Transition.TRANSITION_CLEANUP)
+    node.destroy_node()
+
+
+@skip_without_gripper
 def test_driver_implements_show_specification(lifecycle_interface):
     driver = lifecycle_interface
     driver.change_state(Transition.TRANSITION_CONFIGURE)

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -305,7 +305,7 @@ def test_driver_implements_grip_and_release(lifecycle_interface):
 
 
 @skip_without_gripper
-def test_driver_implements_grip_at_position_and_release(lifecycle_interface):
+def test_driver_implements_grip_at_position(lifecycle_interface):
     driver = lifecycle_interface
 
     node = Node("check_grip_at_position")
@@ -341,14 +341,6 @@ def test_driver_implements_grip_at_position_and_release(lifecycle_interface):
             timeout_sec=5
         ), f"{gripper}: grip_at_position service unavailable"
 
-        release_service_name = f"/schunk/driver/{gripper}/release"
-        ReleaseServiceType = driver.get_service_type(release_service_name)
-        assert ReleaseServiceType is not None, f"{gripper}: release service not found"
-        release_client = node.create_client(ReleaseServiceType, release_service_name)
-        assert release_client.wait_for_service(
-            timeout_sec=5
-        ), f"{gripper}: release service unavailable"
-
         targets = [
             {"force": 50, "position": 0.01, "use_gpe": False, "outward": False},
             {"force": 100, "position": 0.02, "use_gpe": True, "outward": False},
@@ -366,12 +358,6 @@ def test_driver_implements_grip_at_position_and_release(lifecycle_interface):
                 grip_req.use_gpe = target["use_gpe"]
 
             future = grip_client.call_async(grip_req)
-            rclpy.spin_until_future_complete(node, future)
-            assert future.result().success, f"{gripper}: {future.result().message}"
-
-            # Release
-            release_req = ReleaseServiceType.Request()
-            future = release_client.call_async(release_req)
             rclpy.spin_until_future_complete(node, future)
             assert future.result().success, f"{gripper}: {future.result().message}"
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -381,44 +381,6 @@ def test_driver_implements_grip_at_position_and_release(lifecycle_interface):
 
 
 @skip_without_gripper
-def test_driver_implements_grip_at_position_with_or_without_gpe(lifecycle_interface):
-    driver = lifecycle_interface
-    driver.change_state(Transition.TRANSITION_CONFIGURE)
-    driver.change_state(Transition.TRANSITION_ACTIVATE)
-
-    node = Node("grip_at_position_service_with_or_without_gpe")
-
-    for gripper in driver.list_grippers():
-        service_name = f"/schunk/driver/{gripper}/grip_at_position"
-
-        ServiceType = driver.get_service_type(service_name)
-        assert ServiceType is not None, f"{gripper}: service type not found"
-
-        client = node.create_client(ServiceType, service_name)
-        assert client.wait_for_service(timeout_sec=5), f"{gripper}: service unavailable"
-
-        req = ServiceType.Request()
-        req.force = 100
-        req.outward = False
-        req.at_position = 50
-
-        # If the service supports use_gpe, set it
-        if hasattr(req, "use_gpe"):
-            req.use_gpe = False
-        else:
-            assert not hasattr(req, "use_gpe"), f"{gripper}: unexpected use_gpe field"
-
-        future = client.call_async(req)
-        rclpy.spin_until_future_complete(node, future, timeout_sec=5)
-        assert future.result() is not None, f"{gripper}: no response from service"
-
-    driver.change_state(Transition.TRANSITION_DEACTIVATE)
-    driver.change_state(Transition.TRANSITION_CLEANUP)
-
-    node.destroy_node()
-
-
-@skip_without_gripper
 def test_driver_implements_show_specification(lifecycle_interface):
     driver = lifecycle_interface
     driver.change_state(Transition.TRANSITION_CONFIGURE)

--- a/schunk_gripper_interfaces/CMakeLists.txt
+++ b/schunk_gripper_interfaces/CMakeLists.txt
@@ -17,6 +17,8 @@ rosidl_generate_interfaces(
     srv/MoveToAbsolutePosition.srv
     srv/Grip.srv
     srv/GripGPE.srv
+    srv/GripAtPosition.srv
+    srv/GripAtPositionGPE.srv
     srv/Release.srv
     srv/ShowConfiguration.srv
     srv/ShowGripperSpecification.srv

--- a/schunk_gripper_interfaces/srv/GripAtPosition.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPosition.srv
@@ -4,7 +4,7 @@ int8 force    # Percentage points of the gripper's max. gripping force.
 bool outward  # Whether to open the gripper for grasping.
               # Defaults to False.
 
-int32 at_position  # Grip at a specific position
+float32 at_position  # Grip at a specific position in [m]
 ---
 bool success
 string message

--- a/schunk_gripper_interfaces/srv/GripAtPosition.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPosition.srv
@@ -1,0 +1,10 @@
+int8 force    # Percentage points of the gripper's max. gripping force.
+              # Tolerated values in [50, 100]
+
+bool outward  # Whether to open the gripper for grasping.
+              # Defaults to False.
+
+int32 at_position  # Grip at a specific position
+---
+bool success
+string message

--- a/schunk_gripper_interfaces/srv/GripAtPositionGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionGPE.srv
@@ -9,7 +9,7 @@ bool use_gpe  # Whether to activate grip force and position maintenance.
 bool outward  # Whether to open the gripper for grasping.
               # Defaults to False.
 
-int32 at_position  # Grip at a specific position
+float32 at_position  # Grip at a specific position in [m]
 ---
 bool success
 string message

--- a/schunk_gripper_interfaces/srv/GripAtPositionGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionGPE.srv
@@ -1,0 +1,15 @@
+int8 force    # Percentage points of the gripper's max. gripping force.
+              # Tolerated values in [50, 100]
+
+
+bool use_gpe  # Whether to activate grip force and position maintenance.
+              # Will only be used when available in the gripper.
+              # Defaults to False.
+
+bool outward  # Whether to open the gripper for grasping.
+              # Defaults to False.
+
+int32 at_position  # Grip at a specific position
+---
+bool success
+string message

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -351,6 +351,7 @@ class Driver(object):
     def grip(
         self,
         force: int,
+        position: int | None = None,
         use_gpe: bool = False,
         outward: bool = False,
         scheduler: Scheduler | None = None,
@@ -359,19 +360,28 @@ class Driver(object):
             return False
         if not self.set_gripping_force(force):
             return False
+        if position is not None and not isinstance(position, int):
+            return False
+
+        if position is not None:
+            trigger_bit = 16
+        else:
+            trigger_bit = 12
 
         def start() -> bool:
             self.clear_plc_output()
             self.send_plc_output()
 
             cmd_toggle_before = self.get_status_bit(bit=5)
-            self.set_control_bit(bit=12, value=True)
+            self.set_control_bit(bit=trigger_bit, value=True)
             self.set_control_bit(bit=7, value=outward)
             if self.gpe_available():
                 self.set_control_bit(bit=31, value=use_gpe)
             else:
                 self.set_control_bit(bit=31, value=False)
             self.set_gripping_force(force)
+            if position is not None:
+                self.set_target_position(position)
             self.set_target_speed(0)
             self.send_plc_output()
             desired_bits = {"5": cmd_toggle_before ^ 1, "3": 0}
@@ -381,7 +391,9 @@ class Driver(object):
             desired_bits = {"4": 1, "12": 1}
             return self.wait_for_status(bits=desired_bits)
 
-        duration_sec = self.estimate_duration(force=force, outward=outward)
+        duration_sec = self.estimate_duration(
+            position_abs=position, force=force, outward=outward
+        )
         if scheduler:
             if not scheduler.execute(func=partial(start)).result():
                 return False
@@ -459,7 +471,7 @@ class Driver(object):
     def estimate_duration(
         self,
         release: bool = False,
-        position_abs: int = 0,
+        position_abs: int | None = None,
         velocity: int = 0,
         force: int = 0,
         outward: bool = False,
@@ -469,11 +481,18 @@ class Driver(object):
                 self.module_parameters["wp_release_delta"]
                 / self.module_parameters["max_vel"]
             )
-        if not isinstance(position_abs, int):
-            return 0.0
-        if isinstance(velocity, int) and velocity > 0:
+
+        if isinstance(position_abs, int):
             still_to_go = position_abs - self.get_actual_position()
-            return abs(still_to_go) / velocity
+            if isinstance(velocity, int) and velocity > 0:
+                return abs(still_to_go) / velocity
+            if isinstance(force, int) and 0 < force <= 100:
+                grip_vel = (force / 100) * self.module_parameters["max_grp_vel"]
+                return abs(still_to_go) / grip_vel
+            if self.module_parameters.get("max_grp_vel"):
+                return abs(still_to_go) / self.module_parameters["max_grp_vel"]
+            return 0.0
+
         if isinstance(force, int) and force > 0 and force <= 100:
             if outward:
                 still_to_go = (

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -489,8 +489,6 @@ class Driver(object):
             if isinstance(force, int) and 0 < force <= 100:
                 grip_vel = (force / 100) * self.module_parameters["max_grp_vel"]
                 return abs(still_to_go) / grip_vel
-            if self.module_parameters.get("max_grp_vel"):
-                return abs(still_to_go) / self.module_parameters["max_grp_vel"]
             return 0.0
 
         if isinstance(force, int) and force > 0 and force <= 100:

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -481,16 +481,18 @@ def test_driver_estimates_duration_of_grip_at_position():
     def set_actual_position(position: int) -> None:
         driver.plc_input_buffer[4:8] = bytes(struct.pack("i", position))
 
-    # Start near to mid_pos
-    set_actual_position(mid_pos - 1000)
+    positions = [min_pos, min_pos + 500, mid_pos, mid_pos + 500, max_pos, max_pos - 500]
     forces = [50, 75, 100]
 
-    durations = []
-    for force in forces:
-        duration = driver.estimate_duration(position_abs=mid_pos, force=force)
-        durations.append(duration)
+    for pos in positions:
+        # Start near to mid_position
+        set_actual_position(mid_pos - 1000)
+        durations = []
+        for force in forces:
+            duration = driver.estimate_duration(position_abs=pos, force=force)
+            durations.append(duration)
 
-    assert durations[0] > durations[1] > durations[2]
+        assert durations[0] > durations[1] > durations[2]
 
     # Cleanup
     driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -470,6 +470,33 @@ def test_driver_estimates_duration_of_release():
 
 
 @skip_without_gripper
+def test_driver_estimates_duration_of_grip_at_position():
+    driver = Driver()
+
+    driver.connect(serial_port="/dev/ttyUSB0", device_id=12, update_cycle=None)
+    max_pos = driver.module_parameters["max_pos"]
+    min_pos = driver.module_parameters["min_pos"]
+    mid_pos = (min_pos + max_pos) // 2
+
+    def set_actual_position(position: int) -> None:
+        driver.plc_input_buffer[4:8] = bytes(struct.pack("i", position))
+
+    # Start near to mid_pos
+    set_actual_position(mid_pos - 1000)
+    forces = [50, 75, 100]
+
+    durations = []
+    for force in forces:
+        duration = driver.estimate_duration(position_abs=mid_pos, force=force)
+        durations.append(duration)
+
+    assert durations[0] > durations[1] > durations[2]
+
+    # Cleanup
+    driver.disconnect()
+
+
+@skip_without_gripper
 def test_connected_driver_has_module_parameters():
     driver = Driver()
     params = [

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -472,8 +472,8 @@ def test_driver_estimates_duration_of_release():
 @skip_without_gripper
 def test_driver_estimates_duration_of_grip_at_position():
     driver = Driver()
-
     driver.connect(serial_port="/dev/ttyUSB0", device_id=12, update_cycle=None)
+
     max_pos = driver.module_parameters["max_pos"]
     min_pos = driver.module_parameters["min_pos"]
     mid_pos = (min_pos + max_pos) // 2
@@ -481,18 +481,24 @@ def test_driver_estimates_duration_of_grip_at_position():
     def set_actual_position(position: int) -> None:
         driver.plc_input_buffer[4:8] = bytes(struct.pack("i", position))
 
-    positions = [min_pos, min_pos + 500, mid_pos, mid_pos + 500, max_pos, max_pos - 500]
+    # Fix position, vary force
+    set_actual_position(min_pos)
     forces = [50, 75, 100]
+    durations = []
+    for force in forces:
+        duration = driver.estimate_duration(position_abs=mid_pos, force=force)
+        durations.append(duration)
+    assert durations[0] > durations[1] > durations[2]
 
-    for pos in positions:
-        # Start near to mid_position
-        set_actual_position(mid_pos - 1000)
-        durations = []
-        for force in forces:
-            duration = driver.estimate_duration(position_abs=pos, force=force)
-            durations.append(duration)
-
-        assert durations[0] > durations[1] > durations[2]
+    # Fix force, vary position
+    fixed_force = 75
+    positions = [min_pos + 1000, mid_pos, max_pos]
+    durations = []
+    for position in positions:
+        set_actual_position(min_pos)
+        duration = driver.estimate_duration(position_abs=position, force=fixed_force)
+        durations.append(duration)
+    assert durations[0] < durations[1] < durations[2]
 
     # Cleanup
     driver.disconnect()

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_grip_commands.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_grip_commands.py
@@ -68,3 +68,20 @@ def test_grip_fails_when_no_workpiece_detected():
     driver.acknowledge()
     assert not driver.grip(force=75, outward=True)
     driver.disconnect()
+
+
+@skip_without_gripper
+def test_grip_at_position_fails_with_invalid_arguments():
+    driver = Driver()
+
+    driver.connect(host="0.0.0.0", port=8000, device_id=12)
+    driver.acknowledge()
+
+    invalid_positions = [-1000, 1e6, 3.5]
+    invalid_forces = [0, -10, 200]
+
+    for pos in invalid_positions:
+        for force in invalid_forces:
+            assert not driver.grip(force=force, position=pos)
+
+    driver.disconnect()


### PR DESCRIPTION
**Problem Statement**
The ROS 2 service currently includes all possible input fields including optional ones regardless of whether the connected gripper model supports them. This results in confusion for users and unclear interfaces, especially when some grippers do not support specific features.
We intend to separate the `GripAtPosition` and `GripAtPositionGPE` specific feature


**Steps:**
- [x]  Identify the type and service supported
- [x]  Separate the .srv files for `GripAtPosition` and `GripAtPositionGPE`
- [x] Make a type-based distinction in the driver when creating the services
- [x]  Implement the tests
- [ ] Test this with a real gripper