### PR TITLE
Fix output of `--show-args` on driver startup

### DIFF
--- a/schunk_gripper_driver/launch/driver.launch.py
+++ b/schunk_gripper_driver/launch/driver.launch.py
@@ -51,7 +51,7 @@ headless = DeclareLaunchArgument(
     default_value="false",
     description=(
         "Whether to `configure` and `activate` the driver "
-        "using the last successful configuration",
+        "using the last successful configuration"
     ),
 )
 


### PR DESCRIPTION
The additional comma in the `headless` description raised a `TypeError`. It now behaves as expected.