### PR TITLE
Adjust `save_configuration`

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -372,7 +372,6 @@ class Driver(Node):
         self.destroy_service(self.add_gripper_srv)
         self.destroy_service(self.reset_grippers_srv)
         self.destroy_service(self.show_configuration_srv)
-        self.destroy_service(self.save_configuration_srv)
         self.destroy_service(self.load_previous_configuration_srv)
 
         if self.headless:
@@ -568,9 +567,6 @@ class Driver(Node):
         )
         self.show_configuration_srv = self.create_service(
             ShowConfiguration, "~/show_configuration", self._show_configuration_cb
-        )
-        self.save_configuration_srv = self.create_service(
-            Trigger, "~/save_configuration", self._save_configuration_cb
         )
         self.load_previous_configuration_srv = self.create_service(
             Trigger,

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -39,11 +39,11 @@ import pytest
 def test_driver_advertises_state_depending_services(lifecycle_interface):
     driver = lifecycle_interface
     list_grippers = ["/schunk/driver/list_grippers"]
+    save_configuration = ["/schunk/driver/save_configuration"]
     config_services = [
         "/schunk/driver/add_gripper",
         "/schunk/driver/reset_grippers",
         "/schunk/driver/show_configuration",
-        "/schunk/driver/save_configuration",
         "/schunk/driver/load_previous_configuration",
     ]
     gripper_services = [
@@ -63,12 +63,14 @@ def test_driver_advertises_state_depending_services(lifecycle_interface):
         # After startup -> unconfigured
         driver.check_state(State.PRIMARY_STATE_UNCONFIGURED)
         assert driver.check(config_services, dtype="service", should_exist=True)
+        assert driver.check(save_configuration, dtype="service", should_exist=True)
         assert driver.check(list_grippers, dtype="service", should_exist=False)
 
         # After configure -> inactive
         driver.change_state(Transition.TRANSITION_CONFIGURE)
         time.sleep(until_change_takes_effect)
         assert driver.check(list_grippers, dtype="service", should_exist=True)
+        assert driver.check(save_configuration, dtype="service", should_exist=True)
         assert driver.check(config_services, dtype="service", should_exist=False)
         assert driver.check(gripper_services, dtype="service", should_exist=False)
 
@@ -76,6 +78,7 @@ def test_driver_advertises_state_depending_services(lifecycle_interface):
         driver.change_state(Transition.TRANSITION_ACTIVATE)
         time.sleep(until_change_takes_effect)
         assert driver.check(list_grippers, dtype="service", should_exist=True)
+        assert driver.check(save_configuration, dtype="service", should_exist=True)
         assert driver.check(config_services, dtype="service", should_exist=False)
         assert driver.check(gripper_services, dtype="service", should_exist=True)
 
@@ -83,6 +86,7 @@ def test_driver_advertises_state_depending_services(lifecycle_interface):
         driver.change_state(Transition.TRANSITION_DEACTIVATE)
         time.sleep(until_change_takes_effect)
         assert driver.check(list_grippers, dtype="service", should_exist=True)
+        assert driver.check(save_configuration, dtype="service", should_exist=True)
         assert driver.check(config_services, dtype="service", should_exist=False)
         assert driver.check(gripper_services, dtype="service", should_exist=False)
 
@@ -90,6 +94,7 @@ def test_driver_advertises_state_depending_services(lifecycle_interface):
         driver.change_state(Transition.TRANSITION_CLEANUP)
         time.sleep(until_change_takes_effect)
         assert driver.check(config_services, dtype="service", should_exist=True)
+        assert driver.check(save_configuration, dtype="service", should_exist=True)
         assert driver.check(list_grippers, dtype="service", should_exist=False)
 
 


### PR DESCRIPTION
Make `save_configuration` always available

That's helpful when users want to save their configuration after successfully running their setup.
