### PR TITLE
Support the `StrongGripAtPositionGPE` feature

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -33,6 +33,7 @@ from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
     SoftGripAtPosition,
     SoftGripAtPositionGPE,
     StrongGripGPE,
+    StrongGripAtPositionGPE,
     Release,
     StartJogging,
     StartJoggingGPE,
@@ -471,8 +472,8 @@ class Driver(Node):
                 gripper["driver"].get_variant() in ["EGU", "EZU"]
                 and gripper["driver"].gpe_available()
             ):
-                service_types = [StrongGripGPE]
-                service_names = ["strong_grip"]
+                service_types = [StrongGripGPE, StrongGripAtPositionGPE]
+                service_names = ["strong_grip", "strong_grip_at_position"]
                 for srv_name, srv_type in zip(service_names, service_types):
                     self.gripper_services.append(
                         self.create_service(

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_gpe_variants.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_gpe_variants.py
@@ -26,6 +26,7 @@ from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
     SoftGripAtPosition,
     SoftGripAtPositionGPE,
     StrongGripGPE,
+    StrongGripAtPositionGPE,
 )
 
 
@@ -45,6 +46,7 @@ def test_grip_callback_handles_all_gpe_variants(ros2):
         SoftGripAtPosition,
         SoftGripAtPositionGPE,
         StrongGripGPE,
+        StrongGripAtPositionGPE,
     ]
     for gripper in driver.grippers:
         for service_type in service_types:
@@ -70,6 +72,7 @@ def test_driver_offers_gpe_specific_grip_services(ros2):
             "/soft_grip": None,
             "/soft_grip_at_position": None,
             "/strong_grip": StrongGripGPE,
+            "/strong_grip_at_position": StrongGripAtPositionGPE,
         },
         "EGU_50_N_B": {
             "/grip": Grip,
@@ -77,6 +80,7 @@ def test_driver_offers_gpe_specific_grip_services(ros2):
             "/soft_grip": None,
             "/soft_grip_at_position": None,
             "/strong_grip": None,
+            "/strong_grip_at_position": None,
         },
         "EGK_25_M_B": {
             "/grip": GripGPE,
@@ -84,6 +88,7 @@ def test_driver_offers_gpe_specific_grip_services(ros2):
             "/soft_grip": SoftGripGPE,
             "/soft_grip_at_position": SoftGripAtPositionGPE,
             "/strong_grip": None,
+            "/strong_grip_at_position": None,
         },
         "EGK_25_N_B": {
             "/grip": Grip,
@@ -91,6 +96,7 @@ def test_driver_offers_gpe_specific_grip_services(ros2):
             "/soft_grip": SoftGrip,
             "/soft_grip_at_position": SoftGripAtPosition,
             "/strong_grip": None,
+            "/strong_grip_at_position": None,
         },
     }
     for module, services in module_expectations.items():

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -584,6 +584,70 @@ def test_driver_implements_strong_grip(lifecycle_interface):
 
 
 @skip_without_gripper
+def test_driver_implements_strong_grip_at_position(lifecycle_interface):
+    driver = lifecycle_interface
+
+    node = Node("check_strong_grip_at_position")
+    add_client = node.create_client(AddGripper, "/schunk/driver/add_gripper")
+    reset_client = node.create_client(Trigger, "/schunk/driver/reset_grippers")
+    assert add_client.wait_for_service(timeout_sec=2)
+    assert reset_client.wait_for_service(timeout_sec=2)
+
+    # Reset grippers (drop default modbus gripper)
+    reset_req = Trigger.Request()
+    future = reset_client.call_async(reset_req)
+    rclpy.spin_until_future_complete(node, future)
+    assert future.result().success
+
+    add_req = AddGripper.Request()
+    add_req.gripper.host = "0.0.0.0"
+    add_req.gripper.port = 8000
+    future = add_client.call_async(add_req)
+    rclpy.spin_until_future_complete(node, future)
+    assert future.result().success
+
+    driver.change_state(Transition.TRANSITION_CONFIGURE)
+    driver.change_state(Transition.TRANSITION_ACTIVATE)
+
+    for gripper in driver.list_grippers():
+        if not gripper.startswith("EGU") and not gripper.startswith("EZU"):
+            continue
+        service_name = f"/schunk/driver/{gripper}/strong_grip_at_position"
+        ServiceType = driver.get_service_type(service_name)
+        assert (
+            ServiceType is not None
+        ), f"{gripper}: strong_grip_at_position service not found"
+
+        grip_client = node.create_client(ServiceType, service_name)
+        assert grip_client.wait_for_service(
+            timeout_sec=5
+        ), f"{gripper}: strong_grip_at_position service unavailable"
+
+        targets = [
+            {"force": 120, "position": 0.01, "use_gpe": True, "outward": False},
+            {"force": 150, "position": 0.02, "use_gpe": True, "outward": False},
+            {"force": 180, "position": 0.015, "use_gpe": True, "outward": True},
+            {"force": 200, "position": 0.012, "use_gpe": True, "outward": True},
+        ]
+
+        for target in targets:
+            req = ServiceType.Request()
+            req.force = target["force"]
+            req.at_position = target["position"]
+            req.outward = target["outward"]
+            if hasattr(req, "use_gpe"):
+                req.use_gpe = target["use_gpe"]
+
+            future = grip_client.call_async(req)
+            rclpy.spin_until_future_complete(node, future)
+            assert future.result().success, f"{gripper}: {future.result().message}"
+
+    driver.change_state(Transition.TRANSITION_DEACTIVATE)
+    driver.change_state(Transition.TRANSITION_CLEANUP)
+    node.destroy_node()
+
+
+@skip_without_gripper
 def test_driver_implements_show_specification(lifecycle_interface):
     driver = lifecycle_interface
     driver.change_state(Transition.TRANSITION_CONFIGURE)

--- a/schunk_gripper_interfaces/CMakeLists.txt
+++ b/schunk_gripper_interfaces/CMakeLists.txt
@@ -24,6 +24,7 @@ rosidl_generate_interfaces(
     srv/SoftGripAtPosition.srv
     srv/SoftGripAtPositionGPE.srv
     srv/StrongGripGPE.srv
+    srv/StrongGripAtPositionGPE.srv
     srv/Release.srv
     srv/ScanGrippers.srv
     srv/ShowConfiguration.srv

--- a/schunk_gripper_interfaces/srv/StrongGripAtPositionGPE.srv
+++ b/schunk_gripper_interfaces/srv/StrongGripAtPositionGPE.srv
@@ -1,0 +1,15 @@
+int16 force    # Percentage points of the gripper's max. gripping force.
+               # EGU 50, 60, 80: 101 ≤ gripping force [%] ≤ 200
+               # EGU 70: 101 ≤ gripping force [%] ≤ 150
+
+bool use_gpe  # Whether to activate grip force and position maintenance.
+              # Will only be used when available in the gripper.
+              # Defaults to False.
+
+bool outward  # Whether to open the gripper for grasping.
+              # Defaults to False.
+
+float32 at_position  # Grip at a specific position in [m].
+---
+bool success
+string message

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -610,6 +610,41 @@ def test_driver_estimates_duration_of_strong_grip():
 
 
 @skip_without_gripper
+def test_driver_estimates_duration_of_strong_grip_at_position():
+    driver = Driver()
+    driver.connect(serial_port="/dev/ttyUSB0", device_id=12, update_cycle=None)
+
+    max_pos = driver.module_parameters["max_pos"]
+    min_pos = driver.module_parameters["min_pos"]
+    mid_pos = (min_pos + max_pos) // 2
+
+    def set_actual_position(position: int) -> None:
+        driver.plc_input_buffer[4:8] = bytes(struct.pack("i", position))
+
+    # Fix position, vary force
+    set_actual_position(mid_pos - 1000)
+    forces = [130, 175, 200]
+    durations = []
+    for force in forces:
+        duration = driver.estimate_duration(position_abs=mid_pos, force=force)
+        durations.append(duration)
+    assert durations[0] > durations[1] > durations[2]
+
+    # Fix force, vary position
+    fixed_force = 175
+    positions = [min_pos + 1000, mid_pos, max_pos]
+    durations = []
+    for position in positions:
+        set_actual_position(min_pos)
+        duration = driver.estimate_duration(position_abs=position, force=fixed_force)
+        durations.append(duration)
+    assert durations[0] < durations[1] < durations[2]
+
+    # Cleanup
+    driver.disconnect()
+
+
+@skip_without_gripper
 def test_connected_driver_has_module_parameters():
     driver = Driver()
     params = [

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_grip_commands.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_grip_commands.py
@@ -137,3 +137,19 @@ def test_strong_grip_fails_with_invalid_arguments():
         assert not driver.grip(force=force)
 
     driver.disconnect()
+
+
+@skip_without_gripper
+def test_strong_grip_at_position_fails_with_invalid_arguments():
+    driver = Driver()
+    driver.connect(serial_port="/dev/ttyUSB0", device_id=12)
+    driver.acknowledge()
+
+    invalid_forces = [-50, 0.0, 25.0, 201, 1e9]
+    invalid_positions = [-1000.0, 1e6, 3.5]
+
+    for force in invalid_forces:
+        for pos in invalid_positions:
+            assert not driver.grip(force=force, position=pos)
+
+    driver.disconnect()


### PR DESCRIPTION
**Problem Statement**
The ROS 2 service currently includes all possible input fields including optional ones regardless of whether the connected gripper model supports them. This results in confusion for users and unclear interfaces, especially when some grippers do not support specific features.
We intend to support `StrongGripAtPositionGPE` specific feature

**Steps:**
- [x]  Identify the type and service supported
- [x]  Separate the .srv file for `StrongGripAtPositionGPE`
- [x]  Make a type-based distinction in the driver when creating the services
- [x]  Implement the tests
- [x]  Test this with a real gripper