### PR TITLE
Support the `MoveToRelativePosition` feature

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -25,6 +25,8 @@ from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
     AddGripper,
     MoveToAbsolutePosition,
     MoveToAbsolutePositionGPE,
+    MoveToRelativePosition,
+    MoveToRelativePositionGPE,
     Grip,
     GripGPE,
     GripAtPosition,
@@ -432,11 +434,14 @@ class Driver(Node):
                 )
             )
             if gripper["driver"].gpe_available():
-                service_types = [MoveToAbsolutePositionGPE]
+                service_types = [MoveToAbsolutePositionGPE, MoveToRelativePositionGPE]
             else:
-                service_types = [MoveToAbsolutePosition]
-            service_names = ["move_to_absolute_position"]
-            for srv_name, srv_type in zip(service_names, service_types):
+                service_types = [MoveToAbsolutePosition, MoveToRelativePosition]
+            service_names = ["move_to_absolute_position", "move_to_relative_position"]
+            is_absolute_flags = [True, False]
+            for srv_name, srv_type, is_absolute in zip(
+                service_names, service_types, is_absolute_flags
+            ):
                 self.gripper_services.append(
                     self.create_service(
                         srv_type,
@@ -444,7 +449,7 @@ class Driver(Node):
                         partial(
                             self._move_to_position_cb,
                             gripper=gripper,
-                            is_absolute=True,
+                            is_absolute=is_absolute,
                         ),
                         callback_group=self.gripper_services_cb_group,
                     )

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -20,6 +20,7 @@ from std_srvs.srv import Trigger
 from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
     AddGripper,
     MoveToAbsolutePosition,
+    MoveToRelativePosition,
     Grip,
     Release,
     StartJogging,
@@ -296,6 +297,30 @@ def test_driver_offers_callback_for_move_to_absolute_position(ros2: None):
             response=res,
             gripper=gripper,
             is_absolute=True,
+        )
+        assert not res.success
+
+    driver.on_deactivate(state=None)
+    driver.on_cleanup(state=None)
+
+
+@skip_without_gripper
+def test_driver_offers_callback_for_move_to_relative_position(ros2: None):
+    driver = Driver("driver")
+    driver.on_configure(state=None)
+    driver.on_activate(state=None)
+
+    # Check if we can call the interface.
+    # It will fail with an empty request, but that's ok.
+    req = MoveToRelativePosition.Request()
+    res = MoveToRelativePosition.Response()
+    for idx, _ in enumerate(driver.grippers):
+        gripper = driver.grippers[idx]
+        driver._move_to_position_cb(
+            request=req,
+            response=res,
+            gripper=gripper,
+            is_absolute=False,
         )
         assert not res.success
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -281,48 +281,27 @@ def test_driver_offers_callbacks_for_acknowledge_and_fast_stop(ros2: None):
 
 
 @skip_without_gripper
-def test_driver_offers_callback_for_move_to_absolute_position(ros2: None):
+def test_driver_offers_callback_for_move_to_position(ros2: None):
     driver = Driver("driver")
     driver.on_configure(state=None)
     driver.on_activate(state=None)
 
     # Check if we can call the interface.
     # It will fail with an empty request, but that's ok.
-    req = MoveToAbsolutePosition.Request()
-    res = MoveToAbsolutePosition.Response()
-    for idx, _ in enumerate(driver.grippers):
-        gripper = driver.grippers[idx]
-        driver._move_to_position_cb(
-            request=req,
-            response=res,
-            gripper=gripper,
-            is_absolute=True,
-        )
-        assert not res.success
 
-    driver.on_deactivate(state=None)
-    driver.on_cleanup(state=None)
+    types = [MoveToAbsolutePosition, MoveToRelativePosition]
+    args = [True, False]
 
-
-@skip_without_gripper
-def test_driver_offers_callback_for_move_to_relative_position(ros2: None):
-    driver = Driver("driver")
-    driver.on_configure(state=None)
-    driver.on_activate(state=None)
-
-    # Check if we can call the interface.
-    # It will fail with an empty request, but that's ok.
-    req = MoveToRelativePosition.Request()
-    res = MoveToRelativePosition.Response()
-    for idx, _ in enumerate(driver.grippers):
-        gripper = driver.grippers[idx]
-        driver._move_to_position_cb(
-            request=req,
-            response=res,
-            gripper=gripper,
-            is_absolute=False,
-        )
-        assert not res.success
+    for service_type, arg in zip(types, args):
+        for idx, _ in enumerate(driver.grippers):
+            gripper = driver.grippers[idx]
+            res = driver._move_to_position_cb(
+                request=service_type.Request(),
+                response=service_type.Response(),
+                gripper=gripper,
+                is_absolute=arg,
+            )
+            assert not res.success
 
     driver.on_deactivate(state=None)
     driver.on_cleanup(state=None)

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_gpe_variants.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_gpe_variants.py
@@ -29,6 +29,8 @@ from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
     StrongGripAtPositionGPE,
     MoveToAbsolutePosition,
     MoveToAbsolutePositionGPE,
+    MoveToRelativePosition,
+    MoveToRelativePositionGPE,
 )
 
 
@@ -76,6 +78,7 @@ def test_driver_offers_gpe_specific_services(ros2):
             "/strong_grip": StrongGripGPE,
             "/strong_grip_at_position": StrongGripAtPositionGPE,
             "/move_to_absolute_position": MoveToAbsolutePositionGPE,
+            "/move_to_relative_position": MoveToRelativePositionGPE,
         },
         "EGU_50_N_B": {
             "/grip": Grip,
@@ -85,6 +88,7 @@ def test_driver_offers_gpe_specific_services(ros2):
             "/strong_grip": None,
             "/strong_grip_at_position": None,
             "/move_to_absolute_position": MoveToAbsolutePosition,
+            "/move_to_relative_position": MoveToRelativePosition,
         },
         "EGK_25_M_B": {
             "/grip": GripGPE,
@@ -94,6 +98,7 @@ def test_driver_offers_gpe_specific_services(ros2):
             "/strong_grip": None,
             "/strong_grip_at_position": None,
             "/move_to_absolute_position": MoveToAbsolutePositionGPE,
+            "/move_to_relative_position": MoveToRelativePositionGPE,
         },
         "EGK_25_N_B": {
             "/grip": Grip,
@@ -103,6 +108,7 @@ def test_driver_offers_gpe_specific_services(ros2):
             "/strong_grip": None,
             "/strong_grip_at_position": None,
             "/move_to_absolute_position": MoveToAbsolutePosition,
+            "/move_to_relative_position": MoveToRelativePosition,
         },
     }
     for module, services in module_expectations.items():
@@ -128,17 +134,20 @@ def test_move_to_position_callback_handles_all_variants(ros2):
     driver.on_configure(state=None)
     driver.on_activate(state=None)
 
-    service_types = [
-        MoveToAbsolutePosition,
-        MoveToAbsolutePositionGPE,
-    ]
+    service_type_and_flag = {
+        MoveToAbsolutePosition: True,
+        MoveToAbsolutePositionGPE: True,
+        MoveToRelativePosition: False,
+        MoveToRelativePositionGPE: False,
+    }
+
     for gripper in driver.grippers:
-        for service_type in service_types:
+        for service_type, is_absolute in service_type_and_flag.items():
             driver._move_to_position_cb(
                 request=service_type.Request(),
                 response=service_type.Response(),
                 gripper=gripper,
-                is_absolute=True,
+                is_absolute=is_absolute,
             )
 
     driver.on_deactivate(state=None)

--- a/schunk_gripper_interfaces/CMakeLists.txt
+++ b/schunk_gripper_interfaces/CMakeLists.txt
@@ -16,6 +16,8 @@ rosidl_generate_interfaces(
     srv/ListGrippers.srv
     srv/MoveToAbsolutePosition.srv
     srv/MoveToAbsolutePositionGPE.srv
+    srv/MoveToRelativePosition.srv
+    srv/MoveToRelativePositionGPE.srv
     srv/Grip.srv
     srv/GripGPE.srv
     srv/GripAtPosition.srv

--- a/schunk_gripper_interfaces/srv/MoveToRelativePosition.srv
+++ b/schunk_gripper_interfaces/srv/MoveToRelativePosition.srv
@@ -1,0 +1,6 @@
+float32 position  # Relative position in [m]
+
+float32 velocity  # Velocity in [m/s]
+---
+bool success
+string message

--- a/schunk_gripper_interfaces/srv/MoveToRelativePositionGPE.srv
+++ b/schunk_gripper_interfaces/srv/MoveToRelativePositionGPE.srv
@@ -1,0 +1,10 @@
+float32 position  # Relative position in [m]
+
+float32 velocity  # Velocity in [m/s]
+
+bool use_gpe      # Whether to activate position maintenance after moving.
+                  # Will only be used when available in the gripper.
+                  # Defaults to False.
+---
+bool success
+string message

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -291,12 +291,15 @@ class Driver(object):
     ) -> bool:
         if not self.connected:
             return False
-        if not self.set_target_position(position):
+        if not self.set_target_position(position, is_absolute=is_absolute):
             return False
         if not self.set_target_speed(velocity):
             return False
 
-        trigger_bit = 13
+        if is_absolute:
+            trigger_bit = 13
+        else:
+            trigger_bit = 14
 
         def start():
             self.clear_plc_output()
@@ -332,26 +335,6 @@ class Driver(object):
             if self.error_in(duration_sec):
                 return False
             return check()
-
-    def move_to_relative_position(
-        self, position: int, velocity: int, use_gpe: bool
-    ) -> bool:
-        if not self.connected:
-            return False
-
-        self.clear_plc_output()
-        self.send_plc_output()
-
-        cmd_toggle_before = self.get_status_bit(bit=5)
-        self.set_control_bit(bit=14, value=True)
-        self.set_control_bit(bit=31, value=use_gpe)
-        self.set_target_position(position)
-        self.set_target_speed(velocity)
-
-        self.send_plc_output()
-        desired_bits = {"5": cmd_toggle_before ^ 1, "13": 1, "4": 1}
-
-        return self.wait_for_status(bits=desired_bits)
 
     def grip(
         self,
@@ -496,7 +479,10 @@ class Driver(object):
             )
 
         if isinstance(position_abs, int):
-            still_to_go = position_abs - self.get_actual_position()
+            if is_absolute:
+                still_to_go = position_abs - self.get_actual_position()
+            else:
+                still_to_go = position_abs
             if isinstance(velocity, int) and velocity > 0:
                 return abs(still_to_go) / velocity
             if isinstance(force, int) and force > 0:
@@ -874,11 +860,11 @@ class Driver(object):
         )
         return diagnostics
 
-    def set_target_position(self, target_pos: int) -> bool:
+    def set_target_position(self, target_pos: int, is_absolute: bool = True) -> bool:
         with self.output_buffer_lock:
             if not isinstance(target_pos, int):
                 return False
-            if target_pos < 0:
+            if is_absolute and target_pos < 0:
                 return False
             data = bytes(struct.pack("i", target_pos))
             if self.fieldbus == "PN":

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -291,7 +291,7 @@ class Driver(object):
     ) -> bool:
         if not self.connected:
             return False
-        if not self.set_target_position(position, is_absolute=is_absolute):
+        if not self.set_target_position(position):
             return False
         if not self.set_target_speed(velocity):
             return False
@@ -860,11 +860,9 @@ class Driver(object):
         )
         return diagnostics
 
-    def set_target_position(self, target_pos: int, is_absolute: bool = True) -> bool:
+    def set_target_position(self, target_pos: int) -> bool:
         with self.output_buffer_lock:
             if not isinstance(target_pos, int):
-                return False
-            if is_absolute and target_pos < 0:
                 return False
             data = bytes(struct.pack("i", target_pos))
             if self.fieldbus == "PN":

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_behavior.py
@@ -166,7 +166,7 @@ def test_move_to_absolute_position_uses_gpe_only_when_available():
 
 @skip_without_gripper
 def test_move_to_relative_position():
-    test_position = -50000
+    test_position = -5000
     test_velocity = 73000
     test_gpe = True
 

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -443,6 +443,46 @@ def test_driver_estimates_duration_of_move_to_absolute_position():
 
 
 @skip_without_gripper
+def test_driver_estimates_duration_of_move_to_relative_position():
+    driver = Driver()
+
+    driver.connect(serial_port="/dev/ttyUSB0", device_id=12, update_cycle=None)
+    max_pos = driver.module_parameters["max_pos"]
+    min_pos = driver.module_parameters["min_pos"]
+    mid_pos = (min_pos + max_pos) // 2
+
+    def set_actual_position(position: int) -> None:
+        driver.plc_input_buffer[4:8] = bytes(struct.pack("i", position))
+
+    # Fix position, vary velocity
+    set_actual_position(mid_pos)
+    rel_move = -10000
+    velocities = [5000, 10000, 15000]
+    durations = []
+    for vel in velocities:
+        duration = driver.estimate_duration(
+            position_abs=rel_move, is_absolute=False, velocity=vel
+        )
+        durations.append(duration)
+    assert durations[0] > durations[1] > durations[2]
+
+    # Fix velocity, vary position
+    relative_moves = [-20000, -10000, 5000]
+    velocity = 10000
+    durations = []
+    for rel_move in relative_moves:
+        set_actual_position(mid_pos)
+        duration = driver.estimate_duration(
+            position_abs=rel_move, is_absolute=False, velocity=velocity
+        )
+        durations.append(duration)
+    assert durations[0] > durations[1] > durations[2]
+
+    # Cleanup
+    driver.disconnect()
+
+
+@skip_without_gripper
 def test_driver_estimates_duration_of_grip_operations():
     driver = Driver()
 

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_control_operations.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_control_operations.py
@@ -64,7 +64,7 @@ def test_driver_supports_reading_and_writing_target_position():
 
 def test_driver_rejects_invalid_target_position():
     driver = Driver()
-    invalid_positions = [12.34, -0.5, -7500, "17.3"]
+    invalid_positions = [12.34, -0.5, -7500.0, "17.3"]
     for pos in invalid_positions:
         assert not driver.set_target_position(pos)
 

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_control_operations.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_control_operations.py
@@ -57,9 +57,10 @@ def test_driver_only_touches_specified_control_bits():
 
 def test_driver_supports_reading_and_writing_target_position():
     driver = Driver()
-    target_pos = 12300  # um
-    driver.set_target_position(target_pos)
-    assert pytest.approx(driver.get_target_position(), rel=1e-3) == target_pos
+    target_positions = [12300, -15001, 1, 0]  # um
+    for target in target_positions:
+        driver.set_target_position(target)
+        assert pytest.approx(driver.get_target_position(), rel=1e-3) == target
 
 
 def test_driver_rejects_invalid_target_position():


### PR DESCRIPTION
**Problem Statement:**
The ROS 2 service currently includes all possible input fields including optional ones regardless of whether the connected gipper model supports them. This results in confusion for users and unclear interfaces, especially when some grippers do not support specific features.
We intend to separate `MoveToRelativePosition` and `MoveToRelativePositionGPE` specific feature

**Steps:**
- [x]  identify the type and service supported
- [x]  Separate the .srv file for MoveToRelativePosition and `MoveToRelativePositionGPE`
- [x]  Make a type-based distinction in the driver when creating the services
- [x]  Implement the tests
- [x]  Test with a real gripper