### PR TITLE
Support partial connects in headless mode

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -382,17 +382,14 @@ class Driver(Node):
                 update_cycle = None
             else:
                 update_cycle = 0.05
-            if not driver.connect(
+            driver.connect(
                 host=gripper["host"],
                 port=gripper["port"],
                 serial_port=gripper["serial_port"],
                 device_id=gripper["device_id"],
                 update_cycle=update_cycle,
-            ):
-                self.get_logger().warn(f"Gripper connect failed: {gripper}")
-                return TransitionCallbackReturn.FAILURE
-            else:
-                self.grippers[idx]["driver"] = driver
+            )
+            self.grippers[idx]["driver"] = driver
 
         # Update empty gripper IDs
         for idx, gripper in enumerate(self.grippers):
@@ -433,16 +430,12 @@ class Driver(Node):
     def on_activate(self, state: State) -> TransitionCallbackReturn:
         self.get_logger().debug("on_activate() is called.")
 
-        # Get every gripper ready to go
+        # Get available grippers ready to go
         for idx, gripper in enumerate(self.grippers):
             if self.needs_synchronize(gripper):
-                success = self.grippers[idx]["driver"].acknowledge(
-                    scheduler=self.scheduler
-                )
+                self.grippers[idx]["driver"].acknowledge(scheduler=self.scheduler)
             else:
-                success = self.grippers[idx]["driver"].acknowledge()
-            if not success:
-                return TransitionCallbackReturn.FAILURE
+                self.grippers[idx]["driver"].acknowledge()
 
         # Gripper-specific services
         for idx, _ in enumerate(self.grippers):

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -246,6 +246,7 @@ class Driver(Node):
             configuration = []
             for gripper in self.grippers:
                 entry: OrderedDict[str, str | int] = OrderedDict()
+                entry["gripper_id"] = gripper["gripper_id"]
                 entry["host"] = gripper["host"]
                 entry["port"] = gripper["port"]
                 entry["serial_port"] = gripper["serial_port"]

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -198,6 +198,23 @@ class Driver(Node):
                 devices.append(id)
         return devices
 
+    def get_unique_id(self, gripper: str) -> str:
+        known_ids = [entry["gripper_id"] for entry in self.grippers]
+
+        def increment(name: str) -> str:
+            if name.split("_")[-1].isdigit():
+                count = int(name.split("_")[-1]) + 1
+                name = "_".join(name.split("_")[:-1])
+                name += f"_{count}"
+            else:
+                name = f"{name}_1"
+            return name
+
+        unique_id = increment(gripper)
+        while unique_id in known_ids:
+            unique_id = increment(unique_id)
+        return unique_id
+
     def show_configuration(self) -> list[GripperConfig]:
         configuration = []
         for gripper in self.grippers:

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -340,7 +340,7 @@ class Driver(Node):
                 update_cycle=None,
             ):
                 return False
-            gripper_id = self.get_unique_id(driver.gripper)
+            gripper_id = self.get_unique_id(driver.gripper_type)
             driver.disconnect()
 
         self.grippers.append(
@@ -391,7 +391,7 @@ class Driver(Node):
         for idx, gripper in enumerate(self.grippers):
             if not gripper["gripper_id"]:
                 self.grippers[idx]["gripper_id"] = self.get_unique_id(
-                    gripper=gripper["driver"].gripper
+                    gripper=gripper["driver"].gripper_type
                 )
 
         # Start cyclic updates with reconnect mechanism for each gripper
@@ -862,7 +862,7 @@ class Driver(Node):
                 cfg.host = host
                 cfg.port = port
                 response.connections.append(cfg)
-                response.grippers.append(driver.gripper)
+                response.grippers.append(driver.gripper_type)
                 driver.disconnect()
 
         return response

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -375,7 +375,7 @@ class Driver(Node):
             return TransitionCallbackReturn.FAILURE
         self.scheduler.start()
 
-        # Connect each gripper
+        # Try to connect each gripper
         for idx, gripper in enumerate(self.grippers):
             driver = GripperDriver()
             if self.needs_synchronize(gripper):
@@ -394,7 +394,14 @@ class Driver(Node):
             else:
                 self.grippers[idx]["driver"] = driver
 
-        # Start cyclic updates for each gripper
+        # Update empty gripper IDs
+        for idx, gripper in enumerate(self.grippers):
+            if not gripper["gripper_id"]:
+                self.grippers[idx]["gripper_id"] = self.get_unique_id(
+                    gripper=gripper["driver"].gripper
+                )
+
+        # Start cyclic updates for each gripper that need special synchronization
         for idx, _ in enumerate(self.grippers):
             gripper = self.grippers[idx]
             if self.needs_synchronize(gripper):

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -209,7 +209,7 @@ def test_driver_checks_if_grippers_need_synchronization(ros2: None):
 def test_driver_doesnt_synchronize_empty_serial_ports(ros2):
     driver = Driver("driver")
     assert driver.reset_grippers()
-    assert driver.add_gripper(host="192.168.0.2", port=8000)
+    assert driver.add_gripper(gripper_id="abc", host="192.168.0.2", port=8000)
 
     other = Gripper(
         {
@@ -218,7 +218,7 @@ def test_driver_doesnt_synchronize_empty_serial_ports(ros2):
             "serial_port": "",
             "device_id": 0,
             "driver": GripperDriver(),
-            "gripper_id": "",
+            "gripper_id": "other",
         }
     )
     driver.grippers.append(other)
@@ -412,11 +412,16 @@ def test_driver_runs_a_scheduler_for_concurrent_tasks(ros2: None):
     assert not scheduler_running()
 
 
+@skip_without_gripper
 def test_driver_offers_adding_grippers(ros2: None):
     driver = Driver("driver")
     driver.grippers.clear()
     assert driver.add_gripper(
-        host="0.0.0.0", port=8000, serial_port="/dev/ttyUSB0", device_id=12
+        gripper_id="",
+        host="0.0.0.0",
+        port=8000,
+        serial_port="/dev/ttyUSB0",
+        device_id=12,
     )
     assert len(driver.grippers) == 1
 
@@ -434,9 +439,28 @@ def test_driver_offers_adding_grippers(ros2: None):
 
     # Valid arguments
     driver.grippers.clear()
-    assert driver.add_gripper(host="0.0.0.0", port=8000)
-    assert driver.add_gripper(serial_port="/dev/ttyUSB0", device_id=12)
+    assert driver.add_gripper(gripper_id="abc", host="0.0.0.0", port=8000)
+    driver.grippers[-1]["gripper_id"] == "abc"
+
+    assert driver.add_gripper(
+        gripper_id="xyz", serial_port="/dev/ttyUSB0", device_id=12
+    )
+    driver.grippers[-1]["gripper_id"] == "xyz"
+
     assert len(driver.grippers) == 2
+
+
+def test_driver_checks_connection_when_adding_grippers(ros2: None):
+    driver = Driver("driver")
+
+    # Check the connection if no gripper id is given
+    assert not driver.add_gripper(host="0.0.0.0", port=1234)
+    assert not driver.add_gripper(serial_port="invalid", device_id=12)
+
+    # Don't check if gripper id has some value
+    driver.reset_grippers()
+    assert driver.add_gripper(gripper_id="abc", host="0.0.0.0", port=1234)
+    assert driver.add_gripper(gripper_id="xyz", serial_port="invalid", device_id=12)
 
 
 def test_driver_offers_getting_unique_gripper_ids(ros2: None):
@@ -469,28 +493,56 @@ def test_driver_offers_getting_unique_gripper_ids(ros2: None):
         assert unique_id == setup["expected"]
 
 
+@skip_without_gripper
+def test_driver_assigns_unique_ids_when_adding_grippers(ros2: None):
+    driver = Driver("driver")
+    driver.reset_grippers()
+
+    assert driver.add_gripper(host="0.0.0.0", port=8000)
+    gripper_id = driver.grippers[-1]["gripper_id"]
+    assert gripper_id.split("_")[-1].isdigit()
+
+    assert driver.add_gripper(serial_port="/dev/ttyUSB0", device_id=12)
+    gripper_id = driver.grippers[-1]["gripper_id"]
+    assert gripper_id.split("_")[-1].isdigit()
+
+
 def test_driver_rejects_adding_duplicate_grippers(ros2: None):
     driver = Driver("driver")
     driver.grippers.clear()
     unique_setups = [
-        {"host": "1", "port": 1},
-        {"host": "2", "port": 2},
+        {"gripper_id": "a", "host": "1", "port": 1},
+        {"gripper_id": "b", "host": "2", "port": 2},
         # TCP/IP takes preference when both are given
-        {"host": "2", "port": 3, "serial_port": "/", "device_id": 12},
-        {"host": "2", "port": 4, "serial_port": "/", "device_id": 12},
-        {"serial_port": "/dev/1", "device_id": 12},
-        {"serial_port": "/dev/2", "device_id": 13},
+        {
+            "gripper_id": "c",
+            "host": "2",
+            "port": 3,
+            "serial_port": "/",
+            "device_id": 12,
+        },
+        {
+            "gripper_id": "d",
+            "host": "2",
+            "port": 4,
+            "serial_port": "/",
+            "device_id": 12,
+        },
+        {"gripper_id": "e", "serial_port": "/dev/1", "device_id": 12},
+        {"gripper_id": "f", "serial_port": "/dev/2", "device_id": 13},
     ]
     for setup in unique_setups:
         assert driver.add_gripper(**setup)  # type: ignore [arg-type]
 
     driver.grippers.clear()
-    driver.add_gripper(host="1", port=1, serial_port="/dev/1", device_id=12)
+    driver.add_gripper(
+        gripper_id="unique", host="1", port=1, serial_port="/dev/1", device_id=12
+    )
     overlapping_setups = [
-        {"host": "1", "port": 1},
-        {"host": "1", "port": 1, "serial_port": "/dev/1"},
-        {"port": 1, "serial_port": "/dev/1", "device_id": 12},
-        {"serial_port": "/dev/1", "device_id": 12},
+        {"gripper_id": "a", "host": "1", "port": 1},
+        {"gripper_id": "b", "host": "1", "port": 1, "serial_port": "/dev/1"},
+        {"gripper_id": "c", "port": 1, "serial_port": "/dev/1", "device_id": 12},
+        {"gripper_id": "d", "serial_port": "/dev/1", "device_id": 12},
     ]
     for setup in overlapping_setups:
         assert not driver.add_gripper(**setup)  # type: ignore [arg-type]
@@ -551,12 +603,19 @@ def test_driver_shows_configuration(ros2: None):
 
     # Add some grippers and check the information
     gripper1 = {
+        "gripper_id": "xyz",
         "host": "abc",
         "port": 1234,
         "serial_port": "$asd/123/?",
         "device_id": 55,
     }
-    gripper2 = {"host": "xyz", "port": 42, "serial_port": "/dev/0", "device_id": 66}
+    gripper2 = {
+        "gripper_id": "abc",
+        "host": "xyz",
+        "port": 42,
+        "serial_port": "/dev/0",
+        "device_id": 66,
+    }
     assert driver.add_gripper(**gripper1)  # type: ignore [arg-type]
     assert driver.add_gripper(**gripper2)  # type: ignore [arg-type]
     config = driver.show_configuration()

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -439,6 +439,36 @@ def test_driver_offers_adding_grippers(ros2: None):
     assert len(driver.grippers) == 2
 
 
+def test_driver_offers_getting_unique_gripper_ids(ros2: None):
+    driver = Driver("driver")
+
+    setups = [
+        {"known": ["a_1", "b_1", "c_1"], "new": "a", "expected": "a_2"},
+        {"known": ["a_1"], "new": "b", "expected": "b_1"},
+        {"known": ["a_2"], "new": "a", "expected": "a_1"},
+    ]
+    for setup in setups:
+
+        # Fill the driver's list of known grippers
+        driver.reset_grippers()
+        for gripper_id in setup["known"]:
+            gripper = Gripper(
+                {
+                    "host": "",
+                    "port": 0,
+                    "serial_port": "",
+                    "device_id": 0,
+                    "driver": GripperDriver(),
+                    "gripper_id": gripper_id,
+                }
+            )
+            driver.grippers.append(gripper)
+
+        # Check
+        unique_id = driver.get_unique_id(gripper=setup["new"])  # type: ignore
+        assert unique_id == setup["expected"]
+
+
 def test_driver_rejects_adding_duplicate_grippers(ros2: None):
     driver = Driver("driver")
     driver.grippers.clear()

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -560,7 +560,7 @@ def test_driver_offers_resetting_grippers(ros2: None):
 
 
 @skip_without_gripper
-def test_driver_schedules_concurrent_tasks(ros2: None):
+def test_driver_schedules_concurrent_module_updates(ros2: None):
     driver = Driver("driver")
     driver.reset_grippers()
 
@@ -583,15 +583,12 @@ def test_driver_schedules_concurrent_tasks(ros2: None):
     driver._add_gripper_cb(request=request_2, response=response)
     assert response.success
 
-    # Grippers with a concurrent serial port can't have an update cycle.
+    # Grippers with a concurrent serial port still have an update cycle.
     driver.on_configure(state=None)
     assert len(driver.grippers) == 2
-    assert not driver.grippers[0]["driver"].polling_thread.is_alive()
-    assert not driver.grippers[1]["driver"].polling_thread.is_alive()
+    assert driver.grippers[0]["driver"].polling_thread.is_alive()
+    assert driver.grippers[1]["driver"].polling_thread.is_alive()
 
-    driver.on_activate(state=None)
-
-    driver.on_deactivate(state=None)
     driver.on_cleanup(state=None)
 
 

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_gpe_variants.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_gpe_variants.py
@@ -92,7 +92,7 @@ def test_driver_offers_gpe_specific_services(ros2):
         },
     }
     for module, services in module_expectations.items():
-        driver.grippers[0]["driver"].module = module
+        driver.grippers[0]["driver"].module_type = module
         driver.on_activate(state=None)
 
         for srv_suffix, expected_type in services.items():

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_headless_mode.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_headless_mode.py
@@ -64,10 +64,17 @@ def test_driver_uses_previous_configuration_in_headless_mode(ros2):
         driver = Driver("driver")
         assert len(driver.grippers) == 0
 
-    # Store a valid configuration for the next test
+    # Store a configuration for the next test.
+    # Let one gripper be unavailable during start up.
+    # This mimics the use case when grippers are only powered after
+    # the driver starts in headless mode.
     config = [
-        {"host": "0.0.0.0", "port": 8000},
-        {"serial_port": "/dev/ttyUSB0", "device_id": 12},
+        {"gripper_id": "gripper_1", "host": "0.0.0.0", "port": 8000},
+        {
+            "gripper_id": "unconnected_gripper",
+            "serial_port": "not available yet",
+            "device_id": 12,
+        },
     ]
     with open(location.joinpath("configuration.json"), "w") as f:
         json.dump(config, f)
@@ -81,6 +88,14 @@ def test_driver_auto_configures_in_headless_mode(lifecycle_interface):
     time.sleep(1.0)
 
     assert driver.check_state(State.PRIMARY_STATE_ACTIVE)
+
+    # Check that the expected gripper services are up,
+    # even for the unconnected gripper
+    gripper_services = [
+        "/schunk/driver/gripper_1/acknowledge",
+        "/schunk/driver/unconnected_gripper/acknowledge",
+    ]
+    assert driver.check(gripper_services, dtype="service", should_exist=True)
 
     # Clean-up for next test
     driver.change_state(Transition.TRANSITION_DEACTIVATE)

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_headless_mode.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_headless_mode.py
@@ -30,8 +30,8 @@ def test_driver_uses_previous_configuration_in_headless_mode(ros2):
     # Store a configuration that the driver should load
     location = Path("/var/tmp/schunk_gripper")
     config = [
-        {"host": "1.2.3.4", "port": 1234},
-        {"serial_port": "hello", "device_id": 42},
+        {"gripper_id": "abc", "host": "1.2.3.4", "port": 1234},
+        {"gripper_id": "xyz", "serial_port": "hello", "device_id": 42},
     ]
     with open(location.joinpath("configuration.json"), "w") as f:
         json.dump(config, f)

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -650,7 +650,7 @@ def test_driver_implements_loading_previous_configuration(driver):
     assert client.wait_for_service(timeout_sec=2)
 
     # Store a valid configuration
-    config = {"host": "0.0.0.0", "port": 80}
+    config = {"gripper_id": "abc", "host": "0.0.0.0", "port": 80}
     location = Path("/var/tmp/schunk_gripper")
     with open(location.joinpath("configuration.json"), "w") as f:
         json.dump([config], f)

--- a/schunk_gripper_dummy/schunk_gripper_dummy/config/read_gripper_parameters.py
+++ b/schunk_gripper_dummy/schunk_gripper_dummy/config/read_gripper_parameters.py
@@ -14,7 +14,7 @@ parameter_codes = "./gripper_parameter_codes.json"
 
 driver = Driver()
 driver.connect(host=args.ip)
-outfile = f"./grippers/{driver.gripper}.json"
+outfile = f"./grippers/{driver.gripper_type}.json"
 driver.disconnect()
 
 

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -200,7 +200,7 @@ class Driver(object):
                 self.web_client = None
 
         self.connected = False
-        self.update_module_parameters()
+        self.clear_module_parameters()
         return True
 
     def start_module_updates(self, scheduler: Scheduler | None = None) -> bool:
@@ -586,15 +586,6 @@ class Driver(object):
         return ""
 
     def update_module_parameters(self) -> bool:
-
-        if not self.connected:
-            for key in self.module_parameters.keys():
-                self.module_parameters[key] = None
-            self.fieldbus = ""
-            self.module_type = ""
-            self.gripper_type = ""
-            return True
-
         if not (fieldbus_param := self.read_module_parameter("0x1130")):
             return False
 
@@ -642,6 +633,14 @@ class Driver(object):
         if not self.gripper_type:
             return False
 
+        return True
+
+    def clear_module_parameters(self) -> bool:
+        for key in self.module_parameters.keys():
+            self.module_parameters[key] = None
+        self.fieldbus = ""
+        self.module_type = ""
+        self.gripper_type = ""
         return True
 
     def read_module_parameter(self, param: str) -> bytearray:

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -53,8 +53,8 @@ class Driver(object):
         self.error_byte: int = 12
         self.warning_byte: int = 14
         self.additional_byte: int = 15
-        self.gripper: str = ""
-        self.module: str = ""
+        self.gripper_type: str = ""
+        self.module_type: str = ""
         self.fieldbus: str = ""
         self.module_parameters: dict = {
             "module_type": None,
@@ -193,21 +193,21 @@ class Driver(object):
             if not self.update_module_parameters():
                 return False
 
-            self.module = self.valid_module_types.get(
+            self.module_type = self.valid_module_types.get(
                 str(self.module_parameters["module_type"]), ""
             )
-            self.gripper = self.compose_gripper_type(
-                module=self.module, fieldbus=self.fieldbus
+            self.gripper_type = self.compose_gripper_type(
+                module_type=self.module_type, fieldbus=self.fieldbus
             )
-            if not self.gripper:
+            if not self.gripper_type:
                 return False
 
         return self.connected
 
     def disconnect(self) -> bool:
-        self.module = ""
+        self.module_type = ""
+        self.gripper_type = ""
         self.fieldbus = ""
-        self.gripper = ""
         self.stop_module_updates()
 
         if self.mb_client and self.mb_client.connected:
@@ -582,9 +582,9 @@ class Driver(object):
             return self.write_module_parameter(self.plc_output, self.plc_output_buffer)
 
     def gpe_available(self) -> bool:
-        if not self.module:
+        if not self.module_type:
             return False
-        keys = self.module.split("_")
+        keys = self.module_type.split("_")
         if len(keys) < 3:
             return False
         if keys[2] == "M":
@@ -592,15 +592,15 @@ class Driver(object):
         return False
 
     def get_variant(self) -> str:
-        if not self.module:
+        if not self.module_type:
             return ""
-        if self.module not in self.valid_module_types.values():
+        if self.module_type not in self.valid_module_types.values():
             return ""
-        if self.module.startswith("EGU"):
+        if self.module_type.startswith("EGU"):
             return "EGU"
-        elif self.module.startswith("EGK"):
+        elif self.module_type.startswith("EGK"):
             return "EGK"
-        elif self.module.startswith("EZU"):
+        elif self.module_type.startswith("EZU"):
             return "EZU"
         return ""
 
@@ -753,13 +753,13 @@ class Driver(object):
     def contains_non_hex_chars(self, buffer: str) -> bool:
         return bool(re.search(r"[^0-9a-fA-F]", buffer))
 
-    def compose_gripper_type(self, module: str, fieldbus: str) -> str:
+    def compose_gripper_type(self, module_type: str, fieldbus: str) -> str:
         if (
-            module not in self.valid_module_types.values()
+            module_type not in self.valid_module_types.values()
             or fieldbus not in self.valid_fieldbus_types.values()
         ):
             return ""
-        entries = module.split("_")
+        entries = module_type.split("_")
         gripper_type = "_".join(
             [entries[0], entries[1], fieldbus, entries[2], entries[3]]
         )

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -278,19 +278,19 @@ def test_connected_driver_has_associated_module_and_fieldbus():
     driver = Driver()
 
     # empty on startup
-    assert not driver.module
+    assert not driver.module_type
     assert not driver.fieldbus
 
     for host, port, serial_port in zip(
         ["0.0.0.0", None], [8000, None], [None, "/dev/ttyUSB0"]
     ):
         driver.connect(host=host, port=port, serial_port=serial_port, device_id=12)
-        assert driver.module in driver.valid_module_types.values()
+        assert driver.module_type in driver.valid_module_types.values()
         assert driver.fieldbus in driver.valid_fieldbus_types.values()
 
         # empty after disconnect
         driver.disconnect()
-        assert not driver.module
+        assert not driver.module_type
         assert not driver.fieldbus
 
 
@@ -321,11 +321,11 @@ def test_driver_can_check_for_gpe_support():
     ]
 
     for type in types_with_gpe:
-        driver.module = type
+        driver.module_type = type
         assert driver.gpe_available()
 
     for type in types_without_gpe:
-        driver.module = type
+        driver.module_type = type
         assert not driver.gpe_available()
 
 
@@ -785,7 +785,7 @@ def test_driver_offers_showing_gripper_specification():
 @skip_without_gripper
 def test_connected_driver_has_associated_gripper():
     driver = Driver()
-    assert not driver.gripper  # empty on startup
+    assert not driver.gripper_type  # empty on startup
 
     for host, port, serial_port in zip(
         ["0.0.0.0", None], [8000, None], [None, "/dev/ttyUSB0"]
@@ -793,7 +793,7 @@ def test_connected_driver_has_associated_gripper():
         driver.connect(host=host, port=port, serial_port=serial_port, device_id=12)
 
         # We have this convention: {EGU|EGK|EZU}_{xx}_{PN|EI|EC|MB}_{M|N}_{B|SD}
-        parts = driver.gripper.split("_")
+        parts = driver.gripper_type.split("_")
         print(parts)
         assert parts[0] in ["EGU", "EGK", "EZU"]
         assert int(parts[1])
@@ -802,16 +802,16 @@ def test_connected_driver_has_associated_gripper():
         assert parts[4] in ["B", "SD"]
 
         driver.disconnect()
-        assert not driver.gripper  # empty after disconnect
+        assert not driver.gripper_type  # empty after disconnect
 
 
 def test_driver_offers_method_for_composing_gripper_type():
     driver = Driver()
 
     invalid_combinations = [
-        {"args": {"module": "EGU_50_", "fieldbus": "EC"}},
-        {"args": {"module": "EGU_50_M_B", "fieldbus": "AA"}},
-        {"args": {"module": "0x?|^$%", "fieldbus": "PN"}},
+        {"args": {"module_type": "EGU_50_", "fieldbus": "EC"}},
+        {"args": {"module_type": "EGU_50_M_B", "fieldbus": "AA"}},
+        {"args": {"module_type": "0x?|^$%", "fieldbus": "PN"}},
     ]
     for entry in invalid_combinations:
         gripper_type = driver.compose_gripper_type(**entry["args"])
@@ -819,27 +819,27 @@ def test_driver_offers_method_for_composing_gripper_type():
 
     valid_combinations = [
         {
-            "args": {"module": "EGU_50_M_B", "fieldbus": "EC"},
+            "args": {"module_type": "EGU_50_M_B", "fieldbus": "EC"},
             "expected": "EGU_50_EC_M_B",
         },
         {
-            "args": {"module": "EGU_80_N_SD", "fieldbus": "EI"},
+            "args": {"module_type": "EGU_80_N_SD", "fieldbus": "EI"},
             "expected": "EGU_80_EI_N_SD",
         },
         {
-            "args": {"module": "EZU_35_N_B", "fieldbus": "MB"},
+            "args": {"module_type": "EZU_35_N_B", "fieldbus": "MB"},
             "expected": "EZU_35_MB_N_B",
         },
         {
-            "args": {"module": "EZU_40_N_SD", "fieldbus": "MB"},
+            "args": {"module_type": "EZU_40_N_SD", "fieldbus": "MB"},
             "expected": "EZU_40_MB_N_SD",
         },
         {
-            "args": {"module": "EGK_25_M_B", "fieldbus": "MB"},
+            "args": {"module_type": "EGK_25_M_B", "fieldbus": "MB"},
             "expected": "EGK_25_MB_M_B",
         },
         {
-            "args": {"module": "EGK_50_N_B", "fieldbus": "PN"},
+            "args": {"module_type": "EGK_50_N_B", "fieldbus": "PN"},
             "expected": "EGK_50_PN_N_B",
         },
     ]
@@ -853,7 +853,7 @@ def test_driver_can_detect_variant():
     assert driver.get_variant() == ""  # when unconnected
 
     for module in driver.valid_module_types.values():
-        driver.module = module
+        driver.module_type = module
         expected = module.split("_")[0]
         assert driver.get_variant() == expected
 
@@ -873,5 +873,5 @@ def test_driver_can_detect_variant():
     ]
 
     for idx, type_str in enumerate(unknown_types):
-        driver.module = type_str
+        driver.module_type = type_str
         assert driver.get_variant() == "", f"wrong type at index: {idx}"

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -715,6 +715,32 @@ def test_driver_offers_updating_internal_module_parameters():
             assert value is None, f"key: {key}"
 
 
+@skip_without_gripper
+def test_driver_offers_clearing_internal_module_parameters():
+    driver = Driver()
+
+    for host, port, serial_port in zip(
+        ["0.0.0.0", None], [8000, None], [None, "/dev/ttyUSB0"]
+    ):
+        driver.connect(
+            host=host,
+            port=port,
+            serial_port=serial_port,
+            device_id=12,
+            update_cycle=None,
+        )
+
+        assert driver.clear_module_parameters()
+        for key, value in driver.module_parameters.items():
+            assert value is None, f"key: {key}"
+
+        # Repetitive
+        for _ in range(3):
+            assert driver.clear_module_parameters()
+            for key, value in driver.module_parameters.items():
+                assert value is None, f"key: {key}"
+
+
 def test_driver_offers_waiting_until_error():
     driver = Driver()
     error_bit = 7

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_communication.py
@@ -710,7 +710,6 @@ def test_driver_offers_updating_internal_module_parameters():
 
         # Values are reset when disconnected
         driver.disconnect()
-        assert driver.update_module_parameters()
         for key, value in driver.module_parameters.items():
             assert value is None, f"key: {key}"
 

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_module_update.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_module_update.py
@@ -2,6 +2,7 @@ from schunk_gripper_library.driver import Driver
 from schunk_gripper_library.utility import skip_without_gripper
 import time
 import pytest
+import threading
 
 
 @skip_without_gripper
@@ -115,3 +116,29 @@ def test_driver_updates_with_specified_cycle():
             assert (
                 driver.update_count >= expected_count
             ), f"with update cycle: {cycle} on host: {host}"
+
+
+def test_driver_offers_starting_module_updates():
+    driver = Driver()
+    threads_before = threading.active_count()
+
+    # Normal usage
+    assert driver.start_module_updates()
+    assert threading.active_count() == threads_before + 1
+    driver.stop_module_updates()
+    assert threading.active_count() == threads_before
+
+    # Normal lifecycle
+    for _ in range(3):
+        driver.start_module_updates()
+        driver.stop_module_updates()
+    assert threading.active_count() == threads_before
+
+    # Repeated starts and stops
+    for _ in range(3):
+        driver.start_module_updates()
+    assert threading.active_count() == threads_before + 1
+
+    for _ in range(3):
+        driver.stop_module_updates()
+    assert threading.active_count() == threads_before


### PR DESCRIPTION
## Background
When running in industrial settings, the ROS2 driver will start-up before the grippers are powered.
This means we need a mechanism that supports these (arbitrary long) delays and is operational once everything is up and in place.

## Points for discussion
- What should happen if only one of the previously saved grippers is responsive?
- What should happen if no gripper is responsive?
- What should the driver's _active_ state mean if not all grippers are functional?
- How can we distinguish between an unpowered but valid gripper and an erroneous entry in the saved configuration?
- Which gripper-specific services should be offered and in which state?

## Approach
- Store the unique _gripper id_ (e.g. EGU_60_MB_N_B_1) in the configuration file and use that for further actions
- Support _configure_ and _activate_ even when some grippers are not yet available
- Make sure that periodic updates succeed (`connected = True`) once the grippers appear

## Steps
- [x] Add the `gripper_id` field to the configuration file
- [x] Modify `add_gripper()`:
  - give it an additional `gripper_id` field 
  - if that field is empty, fetch info from the gripper and set a unique id, fail if this doesn't work
  - if that field is non-empty, assume _headless_ mode and only check the other fields
- [x] During `load_previous_configuration()`, use the `gripper_id` field to avoid that the driver checks for valid connections in `add_gripper()`
- [x] Let `on_configure()` succeed when `headless = True` even when some grippers' `connect()` doesn't work
- [x] Add library functions for `start_module_updates()` and `stop_module_updates()`
- [x] Unify the driver's module update with those functions for both Modbus and TCP/IP grippers
- [x] Refactor the `connect()` method and read relevant parameters in `_module_update()`
- [x] Make sure that the driver gets all required information from grippers that connect later
- [x] Test this on real hardware