### PR TITLE
Catch `IOError` when pulling the Modbus USB-RS485 cable

### DIFF
--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -655,7 +655,7 @@ class Driver(object):
                         slave=self.mb_device_id,
                         no_response_expected=False,
                     )
-                except ModbusIOException:
+                except (ModbusIOException, IOError):
                     return result
 
             # Parse each 2-byte register,

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
@@ -138,6 +138,15 @@ def test_driver_handles_pymodbus_exceptions_during_polling(simulate_pymodbus_fai
     time.sleep(driver.reconnect_interval)
     assert driver.connected
 
+    # Check OSError when pulling the USB-RS485 cable
+    simulate_pymodbus_failure["exception"] = OSError("Someone pulled the cable")
+    time.sleep(0.5)
+    assert driver.polling_thread.is_alive()
+    assert not driver.connected
+    simulate_pymodbus_failure["exception"] = None
+    time.sleep(driver.reconnect_interval)
+    assert driver.connected
+
     driver.disconnect()
 
 


### PR DESCRIPTION
This used to crash the driver. It now works as expected.