### PR TITLE
Catch general `HTTPError`s in `connect()`

### DIFF
--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -5,7 +5,7 @@ from pymodbus.pdu import ModbusPDU
 import re
 from threading import Thread, Event
 import time
-from httpx import Client, ConnectError, ConnectTimeout, ReadTimeout
+from httpx import Client, ConnectError, ConnectTimeout, ReadTimeout, HTTPError
 from importlib.resources import files
 from typing import Union
 import json
@@ -156,6 +156,9 @@ class Driver(object):
                         f"http://{host}:{port}/adi/data.json"
                     ).is_success
                 except (ConnectError, ConnectTimeout):
+                    self.connected = False
+                except HTTPError as e:
+                    print(f"{type(e)}: {e}")
                     self.connected = False
 
         # Modbus

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_reconnection.py
@@ -67,6 +67,14 @@ def test_driver_handles_httpx_exceptions_on_startup(simulate_httpx_failure):
     assert not driver.connect(host="0.0.0.0", port=8000)
     driver.disconnect()
 
+    # Check httpx.HTTPError
+    simulate_httpx_failure["exception"] = httpx.HTTPError(
+        "Something weird we didn't anticipate"
+    )
+    driver = Driver()
+    assert not driver.connect(host="0.0.0.0", port=8000)
+    driver.disconnect()
+
 
 @skip_without_gripper
 def test_driver_handles_httpx_exceptions_during_polling(simulate_httpx_failure):


### PR DESCRIPTION
This one occurred with a WSL and docker setup when starting in headless mode without pyhsical Ethernet connections.