### PR TITLE
[TPA-5715] Add result flags to grip services

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -1143,6 +1143,7 @@ class Driver(Node):
             scheduler=scheduler,
         )
 
+        response.success = False
         if grip_result == gripper["driver"].GripResult.WORKPIECE_GRIPPED:
             response.workpiece_gripped = True
             response.success = True
@@ -1155,8 +1156,6 @@ class Driver(Node):
         elif grip_result == gripper["driver"].GripResult.WORKPIECE_LOST:
             response.workpiece_lost = True
             response.success = True
-        elif grip_result == gripper["driver"].GripResult.ERROR:
-            response.error = True
 
         response.message = gripper["driver"].get_status_diagnostics()
         return response

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -1134,7 +1134,7 @@ class Driver(Node):
         if velocity is not None:
             velocity = int(velocity * 1e6)
 
-        response.success = gripper["driver"].grip(
+        grip_result = gripper["driver"].grip(
             position=position,
             velocity=velocity,
             force=request.force,
@@ -1142,6 +1142,22 @@ class Driver(Node):
             outward=request.outward,
             scheduler=scheduler,
         )
+
+        if grip_result == gripper["driver"].GripResult.WORKPIECE_GRIPPED:
+            response.workpiece_gripped = True
+            response.success = True
+        elif grip_result == gripper["driver"].GripResult.WRONG_WORKPIECE_GRIPPED:
+            response.wrong_workpiece_gripped = True
+            response.success = True
+        elif grip_result == gripper["driver"].GripResult.NO_WORKPIECE_DETECTED:
+            response.no_workpiece_detected = True
+            response.success = True
+        elif grip_result == gripper["driver"].GripResult.WORKPIECE_LOST:
+            response.workpiece_lost = True
+            response.success = True
+        elif grip_result == gripper["driver"].GripResult.ERROR:
+            response.error = True
+
         response.message = gripper["driver"].get_status_diagnostics()
         return response
 

--- a/schunk_gripper_interfaces/srv/Grip.srv
+++ b/schunk_gripper_interfaces/srv/Grip.srv
@@ -12,9 +12,9 @@ bool outward  # Whether to grip the workpiece from the inside
               # Defaults to False.
 ---
 
-# Flags indicating the outcome of the grip action.
-# If the grip action failed, all flags below will be False.
-# If the grip action succeeded, exactly one of the flags below will be True.
+# Flags indicating the outcome of the grip operation.
+# If the grip operation failed, all flags below will be False.
+# If it succeeded, exactly one of the flags below will be True.
 bool workpiece_gripped
 bool no_workpiece_detected
 bool wrong_workpiece_gripped

--- a/schunk_gripper_interfaces/srv/Grip.srv
+++ b/schunk_gripper_interfaces/srv/Grip.srv
@@ -11,5 +11,14 @@ bool outward  # Whether to grip the workpiece from the inside
               # (Fingers are moving outwards).
               # Defaults to False.
 ---
-bool success
-string message
+
+# Flags indicating the outcome of the grip action.
+# If the grip action failed, all flags below will be False.
+# If the grip action succeeded, exactly one of the flags below will be True.
+bool workpiece_gripped
+bool no_workpiece_detected
+bool wrong_workpiece_gripped
+bool workpiece_lost
+
+bool success   # Overall success status; False if an error occurred.
+string message # Human-readable status or error description.

--- a/schunk_gripper_interfaces/srv/GripAtPosition.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPosition.srv
@@ -18,9 +18,9 @@ float32 position  # Expect to grip a workpiece at a specific position in [m]
                   # bit 11 (no wp gripped) in the statusword.
 ---
 
-# Flags indicating the outcome of the grip action.
-# If the grip action failed, all flags below will be False.
-# If the grip action succeeded, exactly one of the flags below will be True.
+# Flags indicating the outcome of the grip operation.
+# If the grip operation failed, all flags below will be False.
+# If it succeeded, exactly one of the flags below will be True.
 bool workpiece_gripped
 bool no_workpiece_detected
 bool wrong_workpiece_gripped

--- a/schunk_gripper_interfaces/srv/GripAtPosition.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPosition.srv
@@ -17,5 +17,14 @@ float32 position  # Expect to grip a workpiece at a specific position in [m]
                   # and the gripper will either set bit 17 (wrong wp gripped) or
                   # bit 11 (no wp gripped) in the statusword.
 ---
-bool success
-string message
+
+# Flags indicating the outcome of the grip action.
+# If the grip action failed, all flags below will be False.
+# If the grip action succeeded, exactly one of the flags below will be True.
+bool workpiece_gripped
+bool no_workpiece_detected
+bool wrong_workpiece_gripped
+bool workpiece_lost
+
+bool success   # Overall success status; False if an error occurred.
+string message # Human-readable status or error description.

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithGPE.srv
@@ -21,5 +21,14 @@ float32 position  # Expect to grip a workpiece (wp) at a specific position in [m
                   # and the gripper will either set bit 17 (wrong wp gripped) or
                   # bit 11 (no wp gripped) in the statusword.
 ---
-bool success
-string message
+
+# Flags indicating the outcome of the grip action.
+# If the grip action failed, all flags below will be False.
+# If the grip action succeeded, exactly one of the flags below will be True.
+bool workpiece_gripped
+bool no_workpiece_detected
+bool wrong_workpiece_gripped
+bool workpiece_lost
+
+bool success   # Overall success status; False if an error occurred.
+string message # Human-readable status or error description.

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithGPE.srv
@@ -22,9 +22,9 @@ float32 position  # Expect to grip a workpiece (wp) at a specific position in [m
                   # bit 11 (no wp gripped) in the statusword.
 ---
 
-# Flags indicating the outcome of the grip action.
-# If the grip action failed, all flags below will be False.
-# If the grip action succeeded, exactly one of the flags below will be True.
+# Flags indicating the outcome of the grip operation.
+# If the grip operation failed, all flags below will be False.
+# If it succeeded, exactly one of the flags below will be True.
 bool workpiece_gripped
 bool no_workpiece_detected
 bool wrong_workpiece_gripped

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithVelocity.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithVelocity.srv
@@ -25,9 +25,9 @@ float32 position  # Expect to grip a workpiece (wp) at a specific position in [m
                   # bit 11 (no wp gripped) in the statusword.
 ---
 
-# Flags indicating the outcome of the grip action.
-# If the grip action failed, all flags below will be False.
-# If the grip action succeeded, exactly one of the flags below will be True.
+# Flags indicating the outcome of the grip operation.
+# If the grip operation failed, all flags below will be False.
+# If it succeeded, exactly one of the flags below will be True.
 bool workpiece_gripped
 bool no_workpiece_detected
 bool wrong_workpiece_gripped

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithVelocity.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithVelocity.srv
@@ -24,5 +24,14 @@ float32 position  # Expect to grip a workpiece (wp) at a specific position in [m
                   # and the gripper will either set bit 17 (wrong wp gripped) or
                   # bit 11 (no wp gripped) in the statusword.
 ---
-bool success
-string message
+
+# Flags indicating the outcome of the grip action.
+# If the grip action failed, all flags below will be False.
+# If the grip action succeeded, exactly one of the flags below will be True.
+bool workpiece_gripped
+bool no_workpiece_detected
+bool wrong_workpiece_gripped
+bool workpiece_lost
+
+bool success   # Overall success status; False if an error occurred.
+string message # Human-readable status or error description.

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithVelocityAndGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithVelocityAndGPE.srv
@@ -27,5 +27,14 @@ float32 position  # Expect to grip a workpiece (wp) at a specific position in [m
                   # and the gripper will either set bit 17 (wrong wp gripped) or
                   # bit 11 (no wp gripped) in the statusword.
 ---
-bool success
-string message
+
+# Flags indicating the outcome of the grip action.
+# If the grip action failed, all flags below will be False.
+# If the grip action succeeded, exactly one of the flags below will be True.
+bool workpiece_gripped
+bool no_workpiece_detected
+bool wrong_workpiece_gripped
+bool workpiece_lost
+
+bool success   # Overall success status; False if an error occurred.
+string message # Human-readable status or error description.

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithVelocityAndGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithVelocityAndGPE.srv
@@ -28,9 +28,9 @@ float32 position  # Expect to grip a workpiece (wp) at a specific position in [m
                   # bit 11 (no wp gripped) in the statusword.
 ---
 
-# Flags indicating the outcome of the grip action.
-# If the grip action failed, all flags below will be False.
-# If the grip action succeeded, exactly one of the flags below will be True.
+# Flags indicating the outcome of the grip operation.
+# If the grip operation failed, all flags below will be False.
+# If it succeeded, exactly one of the flags below will be True.
 bool workpiece_gripped
 bool no_workpiece_detected
 bool wrong_workpiece_gripped

--- a/schunk_gripper_interfaces/srv/GripWithGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripWithGPE.srv
@@ -15,9 +15,9 @@ bool outward  # Whether to grip the workpiece from the inside
               # Defaults to False.
 ---
 
-# Flags indicating the outcome of the grip action.
-# If the grip action failed, all flags below will be False.
-# If the grip action succeeded, exactly one of the flags below will be True.
+# Flags indicating the outcome of the grip operation.
+# If the grip operation failed, all flags below will be False.
+# If it succeeded, exactly one of the flags below will be True.
 bool workpiece_gripped
 bool no_workpiece_detected
 bool wrong_workpiece_gripped

--- a/schunk_gripper_interfaces/srv/GripWithGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripWithGPE.srv
@@ -14,5 +14,14 @@ bool outward  # Whether to grip the workpiece from the inside
               # (Fingers are moving outwards).
               # Defaults to False.
 ---
-bool success
-string message
+
+# Flags indicating the outcome of the grip action.
+# If the grip action failed, all flags below will be False.
+# If the grip action succeeded, exactly one of the flags below will be True.
+bool workpiece_gripped
+bool no_workpiece_detected
+bool wrong_workpiece_gripped
+bool workpiece_lost
+
+bool success   # Overall success status; False if an error occurred.
+string message # Human-readable status or error description.

--- a/schunk_gripper_interfaces/srv/GripWithVelocity.srv
+++ b/schunk_gripper_interfaces/srv/GripWithVelocity.srv
@@ -18,5 +18,14 @@ float32 velocity # Speed for the gripping motion in [m/s].
                  # At 50% force the speed is set to the value of
                  # parameter 0x0628 (min_vel)
 ---
-bool success
-string message
+
+# Flags indicating the outcome of the grip action.
+# If the grip action failed, all flags below will be False.
+# If the grip action succeeded, exactly one of the flags below will be True.
+bool workpiece_gripped
+bool no_workpiece_detected
+bool wrong_workpiece_gripped
+bool workpiece_lost
+
+bool success   # Overall success status; False if an error occurred.
+string message # Human-readable status or error description.

--- a/schunk_gripper_interfaces/srv/GripWithVelocity.srv
+++ b/schunk_gripper_interfaces/srv/GripWithVelocity.srv
@@ -19,9 +19,9 @@ float32 velocity # Speed for the gripping motion in [m/s].
                  # parameter 0x0628 (min_vel)
 ---
 
-# Flags indicating the outcome of the grip action.
-# If the grip action failed, all flags below will be False.
-# If the grip action succeeded, exactly one of the flags below will be True.
+# Flags indicating the outcome of the grip operation.
+# If the grip operation failed, all flags below will be False.
+# If it succeeded, exactly one of the flags below will be True.
 bool workpiece_gripped
 bool no_workpiece_detected
 bool wrong_workpiece_gripped

--- a/schunk_gripper_interfaces/srv/GripWithVelocityAndGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripWithVelocityAndGPE.srv
@@ -22,9 +22,9 @@ float32 velocity # Speed for the gripping motion in [m/s].
                  # parameter 0x0628 (min_vel)
 ---
 
-# Flags indicating the outcome of the grip action.
-# If the grip action failed, all flags below will be False.
-# If the grip action succeeded, exactly one of the flags below will be True.
+# Flags indicating the outcome of the grip operation.
+# If the grip operation failed, all flags below will be False.
+# If it succeeded, exactly one of the flags below will be True.
 bool workpiece_gripped
 bool no_workpiece_detected
 bool wrong_workpiece_gripped

--- a/schunk_gripper_interfaces/srv/GripWithVelocityAndGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripWithVelocityAndGPE.srv
@@ -21,5 +21,14 @@ float32 velocity # Speed for the gripping motion in [m/s].
                  # At 50% force the speed is set to the value of
                  # parameter 0x0628 (min_vel)
 ---
-bool success
-string message
+
+# Flags indicating the outcome of the grip action.
+# If the grip action failed, all flags below will be False.
+# If the grip action succeeded, exactly one of the flags below will be True.
+bool workpiece_gripped
+bool no_workpiece_detected
+bool wrong_workpiece_gripped
+bool workpiece_lost
+
+bool success   # Overall success status; False if an error occurred.
+string message # Human-readable status or error description.

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -396,7 +396,7 @@ class Driver(object):
         if position is not None and not isinstance(position, int):
             return Driver.GripResult.ERROR
         if velocity is not None:
-            if not isinstance(velocity, int) or velocity <= 0:
+            if not isinstance(velocity, int) or velocity < 0:
                 return Driver.GripResult.ERROR
 
         if position is not None:

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_grip_commands.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_grip_commands.py
@@ -4,7 +4,7 @@ from schunk_gripper_library.utility import skip_without_gripper
 
 def test_grip_fails_when_not_connected():
     driver = Driver()
-    assert not driver.grip(force=100)
+    assert driver.grip(force=100) == Driver.GripResult.ERROR
 
 
 @skip_without_gripper
@@ -18,7 +18,7 @@ def test_grip_fails_with_invalid_arguments():
         driver.acknowledge()
         invalid_forces = [0.1, -0.1, 75.0]
         for force in invalid_forces:
-            assert not driver.grip(force)
+            assert driver.grip(force=force) == Driver.GripResult.ERROR
 
         driver.disconnect()
 
@@ -52,11 +52,11 @@ def test_grip_moves_as_expected_with_the_outward_argument():
     middle = int(0.5 * (max_pos - min_pos))
 
     assert driver.acknowledge()
-    driver.grip(force=100, outward=True)
+    assert driver.grip(force=100, outward=True) != Driver.GripResult.ERROR
     assert driver.get_actual_position() > middle
 
     assert driver.acknowledge()
-    driver.grip(force=100, outward=False)
+    assert driver.grip(force=100, outward=False) != Driver.GripResult.ERROR
     assert driver.get_actual_position() < middle
 
     driver.disconnect()
@@ -74,7 +74,7 @@ def test_grip_at_position_fails_with_invalid_arguments():
 
     for pos in invalid_positions:
         for force in invalid_forces:
-            assert not driver.grip(force=force, position=pos)
+            assert driver.grip(force=force, position=pos) == Driver.GripResult.ERROR
 
     driver.disconnect()
 
@@ -90,7 +90,7 @@ def test_grip_with_velocity_fails_with_invalid_arguments():
 
     for vel in invalid_velocities:
         for force in forces:
-            assert not driver.grip(force=force, velocity=vel)
+            assert driver.grip(force=force, velocity=vel) == Driver.GripResult.ERROR
 
     driver.disconnect()
 
@@ -108,6 +108,9 @@ def test_grip_at_position_with_velocity_fails_with_invalid_arguments():
     for pos in invalid_positions:
         for vel in invalid_velocities:
             for force in forces:
-                assert not driver.grip(force=force, position=pos, velocity=vel)
+                assert (
+                    driver.grip(force=force, position=pos, velocity=vel)
+                    == Driver.GripResult.ERROR
+                )
 
     driver.disconnect()


### PR DESCRIPTION
Grip services now provide gripping result flags to better distinguish between different gripping outcomes.