### PR TITLE
Remove default parameter values and start_empty flag

### DIFF
--- a/schunk_gripper_driver/launch/driver.launch.py
+++ b/schunk_gripper_driver/launch/driver.launch.py
@@ -31,19 +31,13 @@ port = DeclareLaunchArgument(
 )
 serial_port = DeclareLaunchArgument(
     "serial_port",
-    default_value="/dev/ttyUSB0",
+    default_value="",
     description="The gripper's serial port",
 )
 device_id = DeclareLaunchArgument(
     "device_id",
     default_value="12",
     description="The gripper's Modbus device id",
-)
-
-start_empty = DeclareLaunchArgument(
-    "start_empty",
-    default_value="false",
-    description="Whether to drop gripper-specific launch arguments",
 )
 
 headless = DeclareLaunchArgument(
@@ -55,7 +49,7 @@ headless = DeclareLaunchArgument(
     ),
 )
 
-args = [host, port, serial_port, device_id, start_empty, headless]
+args = [host, port, serial_port, device_id, headless]
 
 
 def generate_launch_description():
@@ -72,7 +66,6 @@ def generate_launch_description():
                     {"port": LaunchConfiguration("port")},
                     {"serial_port": LaunchConfiguration("serial_port")},
                     {"device_id": LaunchConfiguration("device_id")},
-                    {"start_empty": LaunchConfiguration("start_empty")},
                     {"headless": LaunchConfiguration("headless")},
                 ],
                 respawn=True,

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -93,19 +93,27 @@ class Driver(Node):
         self.init_parameters = {
             "host": "",
             "port": 80,
-            "serial_port": "/dev/ttyUSB0",
+            "serial_port": "",
             "device_id": 12,
-            "start_empty": False,
             "headless": False,
         }
         for name, default_value in self.init_parameters.items():
             self.declare_parameter(name, default_value)
 
-        start_empty = self.get_parameter("start_empty").value
-        if not start_empty:
+        if self.get_parameter("host").value:
             gripper: Gripper = {
                 "host": self.get_parameter("host").value,
                 "port": self.get_parameter("port").value,
+                "serial_port": "",
+                "device_id": 0,
+                "driver": GripperDriver(),
+                "gripper_id": "",
+            }
+            self.grippers.append(gripper)
+        elif self.get_parameter("serial_port").value:
+            gripper: Gripper = {
+                "host": "",
+                "port": 0,
                 "serial_port": self.get_parameter("serial_port").value,
                 "device_id": self.get_parameter("device_id").value,
                 "driver": GripperDriver(),

--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -99,9 +99,9 @@ class Driver(Node):
         }
         for name, default_value in self.init_parameters.items():
             self.declare_parameter(name, default_value)
-
+        gripper: Gripper
         if self.get_parameter("host").value:
-            gripper: Gripper = {
+            gripper = {
                 "host": self.get_parameter("host").value,
                 "port": self.get_parameter("port").value,
                 "serial_port": "",
@@ -111,7 +111,7 @@ class Driver(Node):
             }
             self.grippers.append(gripper)
         elif self.get_parameter("serial_port").value:
-            gripper: Gripper = {
+            gripper = {
                 "host": "",
                 "port": 0,
                 "serial_port": self.get_parameter("serial_port").value,

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -37,6 +37,7 @@ from rclpy.lifecycle import TransitionCallbackReturn
 from threading import Thread
 import time
 
+
 @skip_without_gripper
 def test_driver_manages_a_list_of_grippers(ros2: None):
     driver = Driver("driver")
@@ -568,14 +569,14 @@ def test_driver_rejects_adding_duplicate_grippers(ros2: None):
 def test_driver_offers_resetting_grippers(ros2: None):
     driver = Driver("driver")
     gripper = Gripper(
-    {
-        "host": "",
-        "port": 0,
-        "serial_port": "/dev/ttyUSB0",
-        "device_id": 12,
-        "driver": GripperDriver(),
-        "gripper_id": "",
-    }
+        {
+            "host": "",
+            "port": 0,
+            "serial_port": "/dev/ttyUSB0",
+            "device_id": 12,
+            "driver": GripperDriver(),
+            "gripper_id": "",
+        }
     )
     driver.grippers.append(gripper)
     assert len(driver.grippers) == 1
@@ -623,14 +624,14 @@ def test_driver_schedules_concurrent_module_updates(ros2: None):
 def test_driver_shows_configuration(ros2: None):
     driver = Driver("driver")
     gripper = Gripper(
-    {
-        "host": "",
-        "port": 0,
-        "serial_port": "/dev/ttyUSB0",
-        "device_id": 12,
-        "driver": GripperDriver(),
-        "gripper_id": "",
-    }
+        {
+            "host": "",
+            "port": 0,
+            "serial_port": "/dev/ttyUSB0",
+            "device_id": 12,
+            "driver": GripperDriver(),
+            "gripper_id": "",
+        }
     )
     driver.grippers.append(gripper)
     config = driver.show_configuration()

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_driver.py
@@ -37,7 +37,7 @@ from rclpy.lifecycle import TransitionCallbackReturn
 from threading import Thread
 import time
 
-
+@skip_without_gripper
 def test_driver_manages_a_list_of_grippers(ros2: None):
     driver = Driver("driver")
     assert len(driver.grippers) == 1
@@ -170,6 +170,19 @@ def test_driver_manages_two_threads_for_all_grippers(ros2: None):
 
 def test_driver_checks_if_grippers_need_synchronization(ros2: None):
     driver = Driver("driver")  # with default gripper
+
+    # Same serial port
+    default_gripper = Gripper(
+        {
+            "host": "",
+            "port": 0,
+            "serial_port": "/dev/ttyUSB0",
+            "device_id": 12,
+            "driver": GripperDriver(),
+            "gripper_id": "",
+        }
+    )
+    driver.grippers.append(default_gripper)
 
     # Same serial port
     gripper = Gripper(
@@ -554,6 +567,17 @@ def test_driver_rejects_adding_duplicate_grippers(ros2: None):
 
 def test_driver_offers_resetting_grippers(ros2: None):
     driver = Driver("driver")
+    gripper = Gripper(
+    {
+        "host": "",
+        "port": 0,
+        "serial_port": "/dev/ttyUSB0",
+        "device_id": 12,
+        "driver": GripperDriver(),
+        "gripper_id": "",
+    }
+    )
+    driver.grippers.append(gripper)
     assert len(driver.grippers) == 1
     assert driver.reset_grippers()
     assert len(driver.grippers) == 0
@@ -598,6 +622,17 @@ def test_driver_schedules_concurrent_module_updates(ros2: None):
 
 def test_driver_shows_configuration(ros2: None):
     driver = Driver("driver")
+    gripper = Gripper(
+    {
+        "host": "",
+        "port": 0,
+        "serial_port": "/dev/ttyUSB0",
+        "device_id": 12,
+        "driver": GripperDriver(),
+        "gripper_id": "",
+    }
+    )
+    driver.grippers.append(gripper)
     config = driver.show_configuration()
     assert len(config) == 1  # with default setting
     assert isinstance(config[0], GripperConfig)

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_empty_startup.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_empty_startup.py
@@ -19,9 +19,6 @@ from schunk_gripper_interfaces.srv import (  # type: ignore [attr-defined]
     ShowConfiguration,
 )
 
-# Module-wide settings
-start_empty = True
-
 
 def test_driver_can_start_without_initial_gripper(driver):
     node = Node("test_without_initial_gripper")

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -158,6 +158,7 @@ def test_driver_implements_adding_and_resetting_grippers(driver):
         rclpy.spin_until_future_complete(node, future)
         assert future.result().success
 
+
 @skip_without_gripper
 def test_driver_implements_show_configuration(driver):
     node = Node("check_listing_configuration")

--- a/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/tests/test_services.py
@@ -158,7 +158,7 @@ def test_driver_implements_adding_and_resetting_grippers(driver):
         rclpy.spin_until_future_complete(node, future)
         assert future.result().success
 
-
+@skip_without_gripper
 def test_driver_implements_show_configuration(driver):
     node = Node("check_listing_configuration")
     client = node.create_client(ShowConfiguration, "/schunk/driver/show_configuration")


### PR DESCRIPTION
- Removed default value for serial_port in the drivers launch file.
- Removed start_empty flag, which is not needed anymore.
- Added check in the drivers init function to only create a gripper if serial port or host is given.