### PR TITLE
[TPA-5731] Change float datatypes and make int-conversion failsafe

### DIFF
--- a/schunk_gripper_interfaces/srv/GripAtPosition.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPosition.srv
@@ -11,7 +11,7 @@ bool outward  # Whether to grip the workpiece from the inside
               # (Fingers are moving outwards).
               # Defaults to False.
 
-float32 position  # Expect to grip a workpiece at a specific position in [m]
+float64 position  # Expect to grip a workpiece at a specific position in [m]
                   # If an unexpected workpiece was gripped or
                   # the gripping position was exceeded the command is terminated
                   # and the gripper will either set bit 17 (wrong wp gripped) or

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithGPE.srv
@@ -15,7 +15,7 @@ bool outward  # Whether to grip the workpiece from the inside
               # (Fingers are moving outwards).
               # Defaults to False.
 
-float32 position  # Expect to grip a workpiece (wp) at a specific position in [m]
+float64 position  # Expect to grip a workpiece (wp) at a specific position in [m]
                   # If an unexpected workpiece was gripped or
                   # the gripping position was exceeded the command is terminated
                   # and the gripper will either set bit 17 (wrong wp gripped) or

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithVelocity.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithVelocity.srv
@@ -11,14 +11,14 @@ bool outward  # Whether to grip the workpiece from the inside
               # (Fingers are moving outwards).
               # Defaults to False.
 
-float32 velocity # Speed for the gripping motion in [m/s].
+float64 velocity # Speed for the gripping motion in [m/s].
                  # If set to 0, the speed corresponds to the grip force
                  # At 100% force the speed is set to the value of
                  # parameter 0x0650 (max_grp_vel)
                  # At 50% force the speed is set to the value of
                  # parameter 0x0628 (min_vel)
 
-float32 position  # Expect to grip a workpiece (wp) at a specific position in [m]
+float64 position  # Expect to grip a workpiece (wp) at a specific position in [m]
                   # If an unexpected workpiece was gripped or
                   # the gripping position was exceeded the command is terminated
                   # and the gripper will either set bit 17 (wrong wp gripped) or

--- a/schunk_gripper_interfaces/srv/GripAtPositionWithVelocityAndGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripAtPositionWithVelocityAndGPE.srv
@@ -14,14 +14,14 @@ bool outward  # Whether to grip the workpiece from the inside
               # (Fingers are moving outwards).
               # Defaults to False.
 
-float32 velocity # Speed for the gripping motion in [m/s].
+float64 velocity # Speed for the gripping motion in [m/s].
                  # If set to 0, the speed corresponds to the grip force
                  # At 100% force the speed is set to the value of
                  # parameter 0x0650 (max_grp_vel)
                  # At 50% force the speed is set to the value of
                  # parameter 0x0628 (min_vel)
 
-float32 position  # Expect to grip a workpiece (wp) at a specific position in [m]
+float64 position  # Expect to grip a workpiece (wp) at a specific position in [m]
                   # If an unexpected workpiece was gripped or
                   # the gripping position was exceeded the command is terminated
                   # and the gripper will either set bit 17 (wrong wp gripped) or

--- a/schunk_gripper_interfaces/srv/GripWithVelocity.srv
+++ b/schunk_gripper_interfaces/srv/GripWithVelocity.srv
@@ -11,7 +11,7 @@ bool outward  # Whether to grip the workpiece from the inside
               # (Fingers are moving outwards).
               # Defaults to False.
 
-float32 velocity # Speed for the gripping motion in [m/s].
+float64 velocity # Speed for the gripping motion in [m/s].
                  # If set to 0, the speed corresponds to the grip force
                  # At 100% force the speed is set to the value of
                  # parameter 0x0650 (max_grp_vel)

--- a/schunk_gripper_interfaces/srv/GripWithVelocityAndGPE.srv
+++ b/schunk_gripper_interfaces/srv/GripWithVelocityAndGPE.srv
@@ -14,7 +14,7 @@ bool outward  # Whether to grip the workpiece from the inside
               # (Fingers are moving outwards).
               # Defaults to False.
 
-float32 velocity # Speed for the gripping motion in [m/s].
+float64 velocity # Speed for the gripping motion in [m/s].
                  # If set to 0, the speed corresponds to the grip force
                  # At 100% force the speed is set to the value of
                  # parameter 0x0650 (max_grp_vel)

--- a/schunk_gripper_interfaces/srv/MoveToAbsolutePosition.srv
+++ b/schunk_gripper_interfaces/srv/MoveToAbsolutePosition.srv
@@ -1,6 +1,6 @@
-float32 position  # Absolute position in [m]
+float64 position  # Absolute position in [m]
 
-float32 velocity  # Velocity in [m/s]
+float64 velocity  # Velocity in [m/s]
 ---
 bool success
 string message

--- a/schunk_gripper_interfaces/srv/MoveToAbsolutePositionGPE.srv
+++ b/schunk_gripper_interfaces/srv/MoveToAbsolutePositionGPE.srv
@@ -1,6 +1,6 @@
-float32 position  # Absolute position in [m]
+float64 position  # Absolute position in [m]
 
-float32 velocity  # Velocity in [m/s]
+float64 velocity  # Velocity in [m/s]
 
 bool use_gpe      # Whether to activate position maintenance after moving.
                   # Will only be used when available in the gripper.

--- a/schunk_gripper_interfaces/srv/MoveToRelativePosition.srv
+++ b/schunk_gripper_interfaces/srv/MoveToRelativePosition.srv
@@ -1,6 +1,6 @@
-float32 position  # Relative position in [m]
+float64 position  # Relative position in [m]
 
-float32 velocity  # Velocity in [m/s]
+float64 velocity  # Velocity in [m/s]
 ---
 bool success
 string message

--- a/schunk_gripper_interfaces/srv/MoveToRelativePositionGPE.srv
+++ b/schunk_gripper_interfaces/srv/MoveToRelativePositionGPE.srv
@@ -1,6 +1,6 @@
-float32 position  # Relative position in [m]
+float64 position  # Relative position in [m]
 
-float32 velocity  # Velocity in [m/s]
+float64 velocity  # Velocity in [m/s]
 
 bool use_gpe      # Whether to activate position maintenance after moving.
                   # Will only be used when available in the gripper.

--- a/schunk_gripper_interfaces/srv/StartJogging.srv
+++ b/schunk_gripper_interfaces/srv/StartJogging.srv
@@ -1,4 +1,4 @@
-float32 velocity  # Velocity in [m/s]
+float64 velocity  # Velocity in [m/s]
 ---
 bool success
 string message

--- a/schunk_gripper_interfaces/srv/StartJoggingGPE.srv
+++ b/schunk_gripper_interfaces/srv/StartJoggingGPE.srv
@@ -1,4 +1,4 @@
-float32 velocity  # Velocity in [m/s]
+float64 velocity  # Velocity in [m/s]
 
 bool use_gpe      # Whether to activate position maintenance after moving.
                   # Will only be used when available in the gripper.

--- a/schunk_gripper_library/schunk_gripper_library/tests/test_grip_commands.py
+++ b/schunk_gripper_library/schunk_gripper_library/tests/test_grip_commands.py
@@ -16,7 +16,8 @@ def test_grip_fails_with_invalid_arguments():
         # Invalid arguments
         driver.connect(host=host, port=port, serial_port=serial_port, device_id=12)
         driver.acknowledge()
-        invalid_forces = [0.1, -0.1, 75.0]
+        max_int32 = 2147483647
+        invalid_forces = [0.1, -0.1, 75.0, max_int32 + 1]
         for force in invalid_forces:
             assert driver.grip(force=force) == Driver.GripResult.ERROR
 


### PR DESCRIPTION
- Change float32 -> float64 in services, as float32 introduces inaccuracies that are observable in normal use cases.
- Fix crash when converting large integers to byte arrays