### PR TITLE
Removed Check if gripper is connected in gpe_available function

### DIFF
--- a/schunk_gripper_driver/schunk_gripper_driver/driver.py
+++ b/schunk_gripper_driver/schunk_gripper_driver/driver.py
@@ -602,15 +602,15 @@ class Driver(Node):
                     callback_group=self.gripper_services_cb_group,
                 )
             )
-
-            self.gripper_services.append(
-                self.create_service(
-                    Trigger,
-                    f"~/{gripper_id}/brake_test",
-                    partial(self._brake_test_cb, gripper=gripper),
-                    callback_group=self.gripper_services_cb_group,
+            if gripper["driver"].gpe_available():
+                self.gripper_services.append(
+                    self.create_service(
+                        Trigger,
+                        f"~/{gripper_id}/brake_test",
+                        partial(self._brake_test_cb, gripper=gripper),
+                        callback_group=self.gripper_services_cb_group,
+                    )
                 )
-            )
             self.gripper_services.append(
                 self.create_service(
                     ReadGripperParameter,

--- a/schunk_gripper_library/schunk_gripper_library/driver.py
+++ b/schunk_gripper_library/schunk_gripper_library/driver.py
@@ -655,9 +655,6 @@ class Driver(object):
             return self._write_param_now(self.plc_output, self.plc_output_buffer)
 
     def gpe_available(self) -> bool:
-        if not self.connected:
-            return False
-
         if not self.module_type:
             return False
         keys = self.module_type.split("_")


### PR DESCRIPTION
- The check causes the driver to load wrong service types when loading grippers from a config files and those grippers are not connected.

- Added check if gpe is available when creating the test brake service. This service must not be present if the gripper has no brake.